### PR TITLE
Make it possible to only include base64.hpp without everything

### DIFF
--- a/include/jwt/algorithm.hpp
+++ b/include/jwt/algorithm.hpp
@@ -219,7 +219,7 @@ enum class algorithm
  * Convert the algorithm enum class type to
  * its stringified form.
  */
-jwt::string_view alg_to_str(enum algorithm alg) noexcept
+inline jwt::string_view alg_to_str(enum algorithm alg) noexcept
 {
   switch (alg) {
     case algorithm::HS256: return "HS256";
@@ -243,7 +243,7 @@ jwt::string_view alg_to_str(enum algorithm alg) noexcept
  * Convert stringified algorithm to enum class.
  * The string comparison is case insesitive.
  */
-enum algorithm str_to_alg(const jwt::string_view alg) noexcept
+inline enum algorithm str_to_alg(const jwt::string_view alg) noexcept
 {
   if (!alg.length()) return algorithm::NONE;
 

--- a/include/jwt/base64.hpp
+++ b/include/jwt/base64.hpp
@@ -86,7 +86,7 @@ private:
  *  @in : Input byte string to be encoded.
  *  @len : Length of the input byte string.
  */
-std::string base64_encode(const char* in, size_t len)
+inline std::string base64_encode(const char* in, size_t len)
 {
   std::string result;
   const auto encoded_siz = encoding_size(len);
@@ -189,7 +189,7 @@ private:
  *  @in : Encoded base64 byte string.
  *  @len : Length of the encoded input byte string.
  */
-std::string base64_decode(const char* in, size_t len)
+inline std::string base64_decode(const char* in, size_t len)
 {
   std::string result;
   const auto decoded_siz = decoding_size(len);
@@ -266,7 +266,7 @@ std::string base64_decode(const char* in, size_t len)
  * Returns:
  *  Length of the URL safe base64 encoded byte string.
  */
-size_t base64_uri_encode(char* data, size_t len) noexcept
+inline size_t base64_uri_encode(char* data, size_t len) noexcept
 {
   size_t i = 0;
   size_t j = 0;
@@ -299,7 +299,7 @@ size_t base64_uri_encode(char* data, size_t len) noexcept
  *  @data : URL safe base64 encoded byte string.
  *  @len : Length of the input byte string.
  */
-std::string base64_uri_decode(const char* data, size_t len)
+inline std::string base64_uri_decode(const char* data, size_t len)
 {
   std::string uri_dec;
   uri_dec.resize(len + 4);

--- a/include/jwt/base64.hpp
+++ b/include/jwt/base64.hpp
@@ -25,6 +25,8 @@ SOFTWARE.
 
 #include <array>
 #include <cassert>
+#include <cstring>
+#include <ostream>
 #include "jwt/string_view.hpp"
 
 namespace jwt {

--- a/include/jwt/impl/error_codes.ipp
+++ b/include/jwt/impl/error_codes.ipp
@@ -141,17 +141,17 @@ const VerificationErrorCategory theVerificationErrorCategory {};
 
 
 // Create the AlgorithmErrc error code
-std::error_code make_error_code(AlgorithmErrc err)
+inline std::error_code make_error_code(AlgorithmErrc err)
 {
   return { static_cast<int>(err), theAlgorithmErrCategory };
 }
 
-std::error_code make_error_code(DecodeErrc err)
+inline std::error_code make_error_code(DecodeErrc err)
 {
   return { static_cast<int>(err), theDecodeErrorCategory };
 }
 
-std::error_code make_error_code(VerificationErrc err)
+inline std::error_code make_error_code(VerificationErrc err)
 {
   return { static_cast<int>(err), theVerificationErrorCategory };
 }

--- a/include/jwt/impl/jwt.ipp
+++ b/include/jwt/impl/jwt.ipp
@@ -61,7 +61,7 @@ std::ostream& operator<< (std::ostream& os, const T& obj)
 
 //========================================================================
 
-void jwt_header::decode(const jwt::string_view enc_str, std::error_code& ec)
+inline void jwt_header::decode(const jwt::string_view enc_str, std::error_code& ec)
 {
   ec.clear();
   std::string json_str = base64_decode(enc_str);
@@ -114,7 +114,7 @@ void jwt_header::decode(const jwt::string_view enc_str, std::error_code& ec)
   return;
 }
 
-void jwt_header::decode(const jwt::string_view enc_str)
+inline void jwt_header::decode(const jwt::string_view enc_str)
 {
   std::error_code ec;
   decode(enc_str, ec);
@@ -124,7 +124,7 @@ void jwt_header::decode(const jwt::string_view enc_str)
   return;
 }
 
-void jwt_payload::decode(const jwt::string_view enc_str, std::error_code& ec)
+inline void jwt_payload::decode(const jwt::string_view enc_str, std::error_code& ec)
 {
   ec.clear();
   std::string json_str = base64_decode(enc_str);
@@ -146,7 +146,7 @@ void jwt_payload::decode(const jwt::string_view enc_str, std::error_code& ec)
   return;
 }
 
-void jwt_payload::decode(const jwt::string_view enc_str)
+inline void jwt_payload::decode(const jwt::string_view enc_str)
 {
   std::error_code ec;
   decode(enc_str, ec);
@@ -156,7 +156,7 @@ void jwt_payload::decode(const jwt::string_view enc_str)
   return;
 }
 
-std::string jwt_signature::encode(const jwt_header& header,
+inline std::string jwt_signature::encode(const jwt_header& header,
                                   const jwt_payload& payload,
                                   std::error_code& ec)
 {
@@ -191,7 +191,7 @@ std::string jwt_signature::encode(const jwt_header& header,
   return jwt_msg;
 }
 
-verify_result_t jwt_signature::verify(const jwt_header& header,
+inline verify_result_t jwt_signature::verify(const jwt_header& header,
                            const jwt::string_view hdr_pld_sign,
                            const jwt::string_view jwt_sign)
 {
@@ -200,7 +200,7 @@ verify_result_t jwt_signature::verify(const jwt_header& header,
 }
 
 
-sign_func_t 
+inline sign_func_t
 jwt_signature::get_sign_algorithm_impl(const jwt_header& hdr) const noexcept
 {
   sign_func_t ret = nullptr;
@@ -245,7 +245,7 @@ jwt_signature::get_sign_algorithm_impl(const jwt_header& hdr) const noexcept
 
 
 
-verify_func_t 
+inline verify_func_t
 jwt_signature::get_verify_algorithm_impl(const jwt_header& hdr) const noexcept
 {
   verify_func_t ret = nullptr;
@@ -337,13 +337,13 @@ void jwt_object::set_parameters(
   set_parameters(std::forward<Rest>(rargs)...);
 }
 
-void jwt_object::set_parameters()
+inline void jwt_object::set_parameters()
 {
   //sentinel call
   return;
 }
 
-jwt_object& jwt_object::add_claim(const jwt::string_view name, system_time_t tp)
+inline jwt_object& jwt_object::add_claim(const jwt::string_view name, system_time_t tp)
 {
   return add_claim(
       name,
@@ -352,13 +352,13 @@ jwt_object& jwt_object::add_claim(const jwt::string_view name, system_time_t tp)
       );
 }
 
-jwt_object& jwt_object::remove_claim(const jwt::string_view name)
+inline jwt_object& jwt_object::remove_claim(const jwt::string_view name)
 {
   payload_.remove_claim(name);
   return *this;
 }
 
-std::string jwt_object::signature(std::error_code& ec) const
+inline std::string jwt_object::signature(std::error_code& ec) const
 {
   ec.clear();
 
@@ -374,7 +374,7 @@ std::string jwt_object::signature(std::error_code& ec) const
   return jws.encode(header_, payload_, ec);
 }
 
-std::string jwt_object::signature() const
+inline std::string jwt_object::signature() const
 {
   std::error_code ec;
   std::string res = signature(ec);
@@ -514,7 +514,7 @@ std::error_code jwt_object::verify(
 }
 
 
-std::array<jwt::string_view, 3>
+inline std::array<jwt::string_view, 3>
 jwt_object::three_parts(const jwt::string_view enc_str)
 {
   std::array<jwt::string_view, 3> result;

--- a/include/jwt/jwt.hpp
+++ b/include/jwt/jwt.hpp
@@ -58,7 +58,7 @@ enum class type
  * Converts a string representing a value of type
  * `enum class type` into its actual type.
  */
-enum type str_to_type(const jwt::string_view typ) noexcept
+inline enum type str_to_type(const jwt::string_view typ) noexcept
 {
   assert (typ.length() && "Empty type string");
 
@@ -72,7 +72,7 @@ enum type str_to_type(const jwt::string_view typ) noexcept
  * Converts an instance of type `enum class type`
  * to its string equivalent.
  */
-jwt::string_view type_to_str(enum type typ)
+inline jwt::string_view type_to_str(enum type typ)
 {
   switch (typ) {
     case type::JWT: return "JWT";
@@ -109,7 +109,7 @@ enum class registered_claims
  * Converts an instance of type `enum class registered_claims`
  * to its string equivalent representation.
  */
-jwt::string_view reg_claims_to_str(enum registered_claims claim) noexcept
+inline jwt::string_view reg_claims_to_str(enum registered_claims claim) noexcept
 {
   switch (claim) {
     case registered_claims::expiration: return "exp";

--- a/include/jwt/parameters.hpp
+++ b/include/jwt/parameters.hpp
@@ -265,7 +265,7 @@ using param_seq_list_t  = std::initializer_list<jwt::string_view>;
 
 /**
  */
-detail::payload_param<std::unordered_map<std::string, std::string>>
+inline detail::payload_param<std::unordered_map<std::string, std::string>>
 payload(const param_init_list_t& kvs)
 {
   std::unordered_map<std::string, std::string> m;
@@ -292,28 +292,28 @@ payload(MappingConcept&& mc)
 
 /**
  */
-detail::secret_param secret(const string_view sv)
+inline detail::secret_param secret(const string_view sv)
 {
   return { sv };
 }
 
 /**
  */
-detail::algorithm_param algorithm(const string_view sv)
+inline detail::algorithm_param algorithm(const string_view sv)
 {
   return { sv };
 }
 
 /**
  */
-detail::algorithm_param algorithm(jwt::algorithm alg)
+inline detail::algorithm_param algorithm(jwt::algorithm alg)
 {
   return { alg };
 }
 
 /**
  */
-detail::headers_param<std::map<std::string, std::string>>
+inline detail::headers_param<std::map<std::string, std::string>>
 headers(const param_init_list_t& kvs)
 {
   std::map<std::string, std::string> m;
@@ -339,7 +339,7 @@ headers(MappingConcept&& mc)
 
 /**
  */
-detail::verify_param
+inline detail::verify_param
 verify(bool v)
 {
   return { v };
@@ -347,7 +347,7 @@ verify(bool v)
 
 /**
  */
-detail::leeway_param
+inline detail::leeway_param
 leeway(uint32_t l)
 {
   return { l };
@@ -355,7 +355,7 @@ leeway(uint32_t l)
 
 /**
  */
-detail::algorithms_param<std::vector<std::string>>
+inline detail::algorithms_param<std::vector<std::string>>
 algorithms(const param_seq_list_t& seq)
 {
   std::vector<std::string> vec;
@@ -375,7 +375,7 @@ algorithms(SequenceConcept&& sc)
 
 /**
  */
-detail::audience_param
+inline detail::audience_param
 aud(const jwt::string_view aud)
 {
   return { aud.data() };
@@ -383,7 +383,7 @@ aud(const jwt::string_view aud)
 
 /**
  */
-detail::issuer_param
+inline detail::issuer_param
 issuer(const jwt::string_view iss)
 {
   return { iss.data() };
@@ -391,7 +391,7 @@ issuer(const jwt::string_view iss)
 
 /**
  */
-detail::subject_param
+inline detail::subject_param
 sub(const jwt::string_view subj)
 {
   return { subj.data() };
@@ -399,7 +399,7 @@ sub(const jwt::string_view subj)
 
 /**
  */
-detail::validate_iat_param
+inline detail::validate_iat_param
 validate_iat(bool v)
 {
   return { v };
@@ -407,7 +407,7 @@ validate_iat(bool v)
 
 /**
  */
-detail::validate_jti_param
+inline detail::validate_jti_param
 validate_jti(bool v)
 {
   return { v };
@@ -415,7 +415,7 @@ validate_jti(bool v)
 
 /**
  */
-detail::nbf_param
+inline detail::nbf_param
 nbf(const system_time_t tp)
 {
   return { tp };
@@ -423,7 +423,7 @@ nbf(const system_time_t tp)
 
 /**
  */
-detail::nbf_param
+inline detail::nbf_param
 nbf(const uint64_t epoch)
 {
   return { epoch };


### PR DESCRIPTION
Make it possible to only include base64.hpp without having to include jwt.hpp by adding missing includes to resolve incomplete types.