### PR TITLE
Fix a major error in error_code category checking implementations.

### DIFF
--- a/include/jwt/impl/jwt.ipp
+++ b/include/jwt/impl/jwt.ipp
@@ -761,7 +761,8 @@ void jwt_throw_exception(const std::error_code& ec)
 {
   const auto& cat = ec.category();
 
-  if (&cat == &theVerificationErrorCategory)
+  if (&cat == &theVerificationErrorCategory ||
+      std::string(cat.name()) == std::string(theVerificationErrorCategory.name()))
   {
     switch (static_cast<VerificationErrc>(ec.value()))
     {
@@ -810,7 +811,8 @@ void jwt_throw_exception(const std::error_code& ec)
     };
   }
 
-  if (&cat == &theDecodeErrorCategory)
+  if (&cat == &theDecodeErrorCategory ||
+      std::string(cat.name()) == std::string(theDecodeErrorCategory.name()))
   {
     switch (static_cast<DecodeErrc>(ec.value()))
     {
@@ -836,7 +838,8 @@ void jwt_throw_exception(const std::error_code& ec)
     assert (0 && "Unknown error code");
   }
 
-  if (&cat == &theAlgorithmErrCategory)
+  if (&cat == &theAlgorithmErrCategory ||
+      std::string(cat.name()) == std::string(theAlgorithmErrCategory.name()))
   {
     switch (static_cast<AlgorithmErrc>(ec.value()))
     {


### PR DESCRIPTION
Errors some times don't throw exceptions due to implementation and linking differences. 

Basically the first symptoms were that the release mode was throwing an exception but not the debug mode. I eventually found this explaining the issue:

https://stackoverflow.com/a/43011009/1317944

This took me a few hours to figure out. I suggest that you merge this to avoid implementation dependent issues. Phew... I hope there's no more of these! 
