### PR TITLE
Fixed many warnings that appear due to assert not being executed in release mode.

### DIFF
--- a/examples/simple_ex2.cc
+++ b/examples/simple_ex2.cc
@@ -37,12 +37,10 @@ int main() {
 
   //Using `add_claim` with extra features.
   //Check return status and overwrite
-  bool ret = obj.payload().add_claim("sub", "new test", false/*overwrite*/);
-  assert (not ret);
+  assert (not obj.payload().add_claim("sub", "new test", false/*overwrite*/));
 
   // Overwrite an existing claim
-  ret = obj.payload().add_claim("sub", "new test", true/*overwrite*/);
-  assert ( ret );
+  assert (obj.payload().add_claim("sub", "new test", true/*overwrite*/));
 
   assert (obj.payload().has_claim_with_value("sub", "new test"));
 

--- a/include/jwt/algorithm.hpp
+++ b/include/jwt/algorithm.hpp
@@ -211,6 +211,7 @@ enum class algorithm
   ES256,
   ES384,
   ES512,
+  UNKN,
   TERM,
 };
 
@@ -233,9 +234,10 @@ inline jwt::string_view alg_to_str(enum algorithm alg) noexcept
     case algorithm::ES512: return "ES512";
     case algorithm::TERM:  return "TERM";
     case algorithm::NONE:  return "NONE";
+    case algorithm::UNKN:  return "UNKN";
     default:               assert (0 && "Unknown Algorithm");
   };
-
+  return "UNKN";
   assert (0 && "Code not reached");
 }
 
@@ -257,6 +259,8 @@ inline enum algorithm str_to_alg(const jwt::string_view alg) noexcept
   if (!strcasecmp(alg.data(), "es256")) return algorithm::ES256;
   if (!strcasecmp(alg.data(), "es384")) return algorithm::ES384;
   if (!strcasecmp(alg.data(), "es512")) return algorithm::ES512;
+
+  return algorithm::UNKN;
 
   assert (0 && "Code not reached");
 }

--- a/include/jwt/impl/error_codes.ipp
+++ b/include/jwt/impl/error_codes.ipp
@@ -49,7 +49,7 @@ struct AlgorithmErrCategory: std::error_category
     case AlgorithmErrc::NoneAlgorithmUsed:
       return "none algorithm used";
     };
-
+    return "unknown algorithm error";
     assert (0 && "Code not reached");
   }
 };
@@ -86,7 +86,7 @@ struct DecodeErrorCategory: std::error_category
     case DecodeErrc::KeyNotRequiredForNoneAlg:
       return "key not required for NONE algorithm";
     };
-
+    return "unknown decode error";
     assert (0 && "Code not reached");
   }
 };
@@ -125,7 +125,7 @@ struct VerificationErrorCategory: std::error_category
     case VerificationErrc::TypeConversionError:
       return "type conversion error";
     };
-
+    return "unknown verification error";
     assert (0 && "Code not reached");
   }
 };

--- a/include/jwt/jwt.hpp
+++ b/include/jwt/jwt.hpp
@@ -64,6 +64,8 @@ inline enum type str_to_type(const jwt::string_view typ) noexcept
 
   if (!strcasecmp(typ.data(), "jwt")) return type::JWT;
 
+  throw std::runtime_error("Unknown token type");
+
   assert (0 && "Code not reached");
 }
 
@@ -121,7 +123,7 @@ inline jwt::string_view reg_claims_to_str(enum registered_claims claim) noexcept
     case registered_claims::jti:        return "jti";
     default:                            assert (0 && "Not a registered claim");
   };
-
+  return "";
   assert (0 && "Code not reached");
 }
 


### PR DESCRIPTION
Like I said before, I don't prefer to see any warnings. I even don't like seeing `assert()` because it's the source of evil. Check the cryptocurrency EOS, and their huge bug that was announced yesterday, which was not found due to using `assert()`.

I haven't removed the asserts, btw. I just found ways to avoid getting all these warnings. So please remove them at your convenience.

Alternatively, I suggest throwing exceptions instead of `assert()`ing. I believe that an error is an error. It's not just an error only in debug mode. What is it gonna cost? Another boolean comparison? In a JWT implementation that's nothing. You don't want to get into the mess of build systems and their considerations of what's debug mode and what's otherwise.