### PR TITLE
Fix out of bounds read in base64_decode

### DIFF
--- a/include/jwt/base64.hpp
+++ b/include/jwt/base64.hpp
@@ -200,7 +200,7 @@ inline std::string base64_decode(const char* in, size_t len)
 
   constexpr static const DMap dmap{};
 
-  while (dmap.at(in[bytes_rem - 1]) == -1) { bytes_rem--; }
+  while (bytes_rem > 0 && dmap.at(in[bytes_rem - 1]) == -1) { bytes_rem--; }
 
   while (bytes_rem > 4)
   {

--- a/tests/test_jwt_decode.cc
+++ b/tests/test_jwt_decode.cc
@@ -64,6 +64,20 @@ TEST (DecodeTest, DecodeInvalidHeader)
 
 }
 
+TEST (DecodeTest, DecodeEmptyHeader)
+{
+  using namespace jwt::params;
+
+  const char* enc_str =
+    ".eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ.";
+
+  std::error_code ec;
+  auto obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret(""), verify(true));
+  ASSERT_TRUE (ec);
+  EXPECT_EQ (ec.value(), static_cast<int>(jwt::DecodeErrc::JsonParseError));
+
+}
+
 TEST (DecodeTest, DecodeInvalidPayload)
 {
   using namespace jwt::params;


### PR DESCRIPTION
`jwt::base64_decode` (and also `jwt::base64_uri_decode`) may crash when the provided buffer does not contain any valid base64 characters while it is attempting to ignore/remove invalid characters from the end. This is easily triggered by attempting to decode a JWT token with an empty header, which is what the included test does.

After adding the new test but before fixing the code, this was the test result:
```
[ RUN      ] DecodeTest.DecodeEmptyHeader
test_jwt_decode: /home/matt/cpp-jwt/include/jwt/base64.hpp:158: jwt::DMap::at(size_t) const::<lambda()>: Assertion `!"pos < map_.size()"' failed.
Aborted (core dumped)
```

After the fix:
```
[ RUN      ] DecodeTest.DecodeEmptyHeader
[       OK ] DecodeTest.DecodeEmptyHeader (0 ms)
```