### PR TITLE
issue-33: Add test showing how to invoke move ctor

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,20 +5,23 @@ link_directories(${OPENSSL_LIBRARIES})
 SET(CERT_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/certs")
 SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DCERT_ROOT_DIR=\"\\\"${CERT_ROOT_DIR}\\\"\"")
 
+add_executable(test_jwt_object test_jwt_object.cc)
+target_link_libraries(test_jwt_object ssl crypto gtest pthread)
+
 add_executable(test_jwt_encode test_jwt_encode.cc)
-target_link_libraries(test_jwt_encode ssl crypto gtest)
+target_link_libraries(test_jwt_encode ssl crypto gtest pthread)
 
 add_executable(test_jwt_decode test_jwt_decode.cc)
-target_link_libraries(test_jwt_decode ssl crypto gtest)
+target_link_libraries(test_jwt_decode ssl crypto gtest pthread)
 
 add_executable(test_jwt_decode_verifiy test_jwt_decode_verifiy.cc)
-target_link_libraries(test_jwt_decode_verifiy ssl crypto gtest)
+target_link_libraries(test_jwt_decode_verifiy ssl crypto gtest pthread)
 
 add_executable(test_jwt_decode_verifiy_with_exception test_jwt_decode_verifiy_with_exception.cc)
-target_link_libraries(test_jwt_decode_verifiy_with_exception ssl crypto gtest)
+target_link_libraries(test_jwt_decode_verifiy_with_exception ssl crypto gtest pthread)
 
 add_executable(test_jwt_rsa test_jwt_rsa.cc)
-target_link_libraries(test_jwt_rsa ssl crypto gtest)
+target_link_libraries(test_jwt_rsa ssl crypto gtest pthread)
 
 add_executable(test_jwt_es test_jwt_es.cc)
-target_link_libraries(test_jwt_es ssl crypto gtest)
+target_link_libraries(test_jwt_es ssl crypto gtest pthread)

--- a/tests/test_jwt_object.cc
+++ b/tests/test_jwt_object.cc
@@ -1,0 +1,35 @@
+#include "gtest/gtest.h"
+#include "jwt/jwt.hpp"
+
+namespace {
+
+struct Wrapper
+{
+    // The std::move here is required to resolve to the move ctor
+    // rather than to the universal reference ctor.
+    Wrapper(jwt::jwt_object&& obj) : object{std::move(obj)} {}
+    jwt::jwt_object object;
+};
+
+} // END namespace
+
+TEST (ObjectTest, MoveConstructor)
+{
+  using namespace jwt::params;
+
+  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+
+  obj.add_claim("iss", "arun.muralidharan");
+
+  auto wrapper = Wrapper{std::move(obj)};
+
+  EXPECT_EQ(wrapper.object.header().algo(), jwt::algorithm::HS256);
+  EXPECT_EQ(wrapper.object.secret(), "secret");
+  EXPECT_TRUE(wrapper.object.payload().has_claim_with_value("iss", "arun.muralidharan"));
+}
+
+int main(int argc, char **argv) 
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
It looks like even if I declare the move constructor explicitly, it doesn't help with the overload resolution. However, if I call `std::move` when invoking the constructor, it will choose the move constructor regardless of whether it is declared explicitly. While there is no change necessary, if you'd like the new unit test that demonstrates the workaround, feel free to merge it.

#33 