### PR TITLE
Some cmake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,13 @@ SET( CMAKE_CXX_FLAGS  "-std=c++14 -Wall" )
 
 include_directories (include)
 
-#find_package(OpenSSL REQUIRED)
+find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
-link_directories(${OPENSSL_LIBRARIES})
+
+find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIRS})
+
+enable_testing()
 
 # Recurse into the "Hello" and "Demo" subdirectories. This does not actually
 # cause another cmake executable to run. The same process will walk through

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ This is a header only library, so you can just add it to your include path and s
 
 For example one can run cmake like:
 ```
-cmake -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2j/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl/1.0.2j/lib/ -DOPENSSL_INCLUDE_DIR=/usr/local/Cellar/openssl/1.0.2j/include/
+cmake -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2j -DGTEST_ROOT=$HOME/googletest
 ```
 
 ## Parameters

--- a/cmake_command
+++ b/cmake_command
@@ -1,1 +1,1 @@
-cmake -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2j/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl/1.0.2j/lib/ -DOPENSSL_INCLUDE_DIR=/usr/local/Cellar/openssl/1.0.2j/include/
+cmake -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2j -DGTEST_ROOT=$HOME/googletest

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,15 +1,18 @@
 
 include_directories(${OPENSSL_INCLUDE_DIR})
-link_directories(${OPENSSL_LIBRARIES})
 
 SET(CERT_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/rsa_256")
 SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DCERT_ROOT_DIR=\"\\\"${CERT_ROOT_DIR}\\\"\"")
 
 add_executable(simple_ex1 simple_ex1.cc)
-target_link_libraries(simple_ex1 ssl crypto gtest)
+target_link_libraries(simple_ex1 ${OPENSSL_LIBRARIES} ${GTEST_LIBRARIES})
+add_test(NAME simple_ex1 COMMAND ./simple_ex1 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(simple_ex2 simple_ex2.cc)
-target_link_libraries(simple_ex2 ssl crypto gtest)
+target_link_libraries(simple_ex2 ${OPENSSL_LIBRARIES} ${GTEST_LIBRARIES})
+add_test(NAME simple_ex2 COMMAND ./simple_ex2 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(simple_ex3_rsa simple_ex3_rsa.cc)
-target_link_libraries(simple_ex3_rsa ssl crypto gtest)
+target_link_libraries(simple_ex3_rsa ${OPENSSL_LIBRARIES} ${GTEST_LIBRARIES})
+add_test(NAME simple_ex3_rsa COMMAND ./simple_ex3_rsa WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,27 +1,33 @@
 
 include_directories(${OPENSSL_INCLUDE_DIR})
-link_directories(${OPENSSL_LIBRARIES})
 
 SET(CERT_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/certs")
 SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DCERT_ROOT_DIR=\"\\\"${CERT_ROOT_DIR}\\\"\"")
 
 add_executable(test_jwt_object test_jwt_object.cc)
-target_link_libraries(test_jwt_object ssl crypto gtest)
+target_link_libraries(test_jwt_object ${OPENSSL_LIBRARIES} ${GTEST_LIBRARIES})
+add_test(NAME test_jwt_object COMMAND ./test_jwt_object WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_jwt_encode test_jwt_encode.cc)
-target_link_libraries(test_jwt_encode ssl crypto gtest)
+target_link_libraries(test_jwt_encode ${OPENSSL_LIBRARIES} ${GTEST_LIBRARIES})
+add_test(NAME test_jwt_encode COMMAND ./test_jwt_encode WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_jwt_decode test_jwt_decode.cc)
-target_link_libraries(test_jwt_decode ssl crypto gtest)
+target_link_libraries(test_jwt_decode ${OPENSSL_LIBRARIES} ${GTEST_LIBRARIES})
+add_test(NAME test_jwt_decode COMMAND ./test_jwt_decode WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_jwt_decode_verifiy test_jwt_decode_verifiy.cc)
-target_link_libraries(test_jwt_decode_verifiy ssl crypto gtest)
+target_link_libraries(test_jwt_decode_verifiy ${OPENSSL_LIBRARIES} ${GTEST_LIBRARIES})
+add_test(NAME test_jwt_decode_verifiy COMMAND ./test_jwt_decode_verifiy WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_jwt_decode_verifiy_with_exception test_jwt_decode_verifiy_with_exception.cc)
-target_link_libraries(test_jwt_decode_verifiy_with_exception ssl crypto gtest)
+target_link_libraries(test_jwt_decode_verifiy_with_exception ${OPENSSL_LIBRARIES} ${GTEST_LIBRARIES})
+add_test(NAME test_jwt_decode_verifiy_with_exception COMMAND ./test_jwt_decode_verifiy_with_exception WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_jwt_rsa test_jwt_rsa.cc)
-target_link_libraries(test_jwt_rsa ssl crypto gtest)
+target_link_libraries(test_jwt_rsa ${OPENSSL_LIBRARIES} ${GTEST_LIBRARIES} )
+add_test(NAME test_jwt_rsa COMMAND ./test_jwt_rsa WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_jwt_es test_jwt_es.cc)
-target_link_libraries(test_jwt_es ssl crypto gtest)
+target_link_libraries(test_jwt_es ${OPENSSL_LIBRARIES} ${GTEST_LIBRARIES})
+add_test(NAME test_jwt_es COMMAND ./test_jwt_es WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
1. Use standard `find_package(OpenSSL)` and `find_package(GTest)` to find required libraries.
2. Use `enable_testing()` and `add_test()` to make it possible to run all tests with `make test`.