### PR TITLE
Add api to supply secret based on decoded payload

### DIFF
--- a/include/jwt/jwt.hpp
+++ b/include/jwt/jwt.hpp
@@ -82,7 +82,7 @@ inline jwt::string_view type_to_str(SCOPED_ENUM type typ)
     case type::JWT: return "JWT";
     default:        assert (0 && "Unknown type");
   };
-
+  __builtin_unreachable();
   assert (0 && "Code not reached");
 }
 
@@ -1120,6 +1120,9 @@ public: //TODO: Not good
   /// Decode parameters
   template <typename DecodeParams, typename... Rest>
   static void set_decode_params(DecodeParams& dparams, params::detail::secret_param s, Rest&&... args);
+
+  template <typename DecodeParams, typename T, typename... Rest>
+  static void set_decode_params(DecodeParams& dparams, params::detail::secret_function_param<T>&& s, Rest&&... args);
 
   template <typename DecodeParams, typename... Rest>
   static void set_decode_params(DecodeParams& dparams, params::detail::leeway_param l, Rest&&... args);

--- a/include/jwt/parameters.hpp
+++ b/include/jwt/parameters.hpp
@@ -84,6 +84,15 @@ struct secret_param
   string_view secret_;
 };
 
+template <typename T>
+struct secret_function_param
+{
+  T get() const { return fun_; }
+  template <typename U>
+  std::string get(U&& u) const { return fun_(u);}
+  T fun_;
+};
+
 /**
  * Parameter for providing the algorithm to use.
  * The parameter can accept either the string representation
@@ -295,6 +304,13 @@ payload(MappingConcept&& mc)
 inline detail::secret_param secret(const string_view sv)
 {
   return { sv };
+}
+
+template <typename T>
+inline std::enable_if_t<!std::is_convertible<T, string_view>::value, detail::secret_function_param<T>>  
+secret(T&& fun)
+{
+  return detail::secret_function_param<T>{ fun };
 }
 
 /**

--- a/tests/test_jwt_es.cc
+++ b/tests/test_jwt_es.cc
@@ -136,6 +136,15 @@ TEST (ESAlgo, ES384EncodingDecodingValidTest)
   EXPECT_EQ (dec_obj.header().algo(), jwt::algorithm::ES384);
   EXPECT_TRUE (dec_obj.has_claim("exp"));
   EXPECT_TRUE (obj.payload().has_claim_with_value("exp", 4682665886));
+
+  std::map<std::string, std::string> keystore{{"arun.muralidharan", key}};
+
+  auto l = [&keystore](const jwt::jwt_payload& payload){ 
+    auto iss = payload.get_claim_value<std::string>("iss");
+    return keystore[iss];
+  };
+  auto dec_obj2 = jwt::decode(enc_str, algorithms({"es384"}), verify(true), secret(l));
+  EXPECT_EQ (dec_obj2.header().algo(), jwt::algorithm::ES384);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Our use case requires the secret to be looked up by the issuer of the payload. This pull request enable user to supply a lambda to query secret during decoding. 