### PR TITLE
'__builtin_unreachable' is not available on Windows

### DIFF
--- a/include/jwt/algorithm.hpp
+++ b/include/jwt/algorithm.hpp
@@ -43,6 +43,7 @@ SOFTWARE.
 #include <openssl/buffer.h>
 #include <openssl/opensslv.h>
 
+#include "jwt/assertions.hpp"
 #include "jwt/exceptions.hpp"
 #include "jwt/string_view.hpp"
 #include "jwt/error_codes.hpp"
@@ -239,7 +240,7 @@ inline jwt::string_view alg_to_str(SCOPED_ENUM algorithm alg) noexcept
     default:               assert (0 && "Unknown Algorithm");
   };
   return "UNKN";
-  assert (0 && "Code not reached");
+  JWT_NOT_REACHED("Code not reached");
 }
 
 /**
@@ -263,7 +264,7 @@ inline SCOPED_ENUM algorithm str_to_alg(const jwt::string_view alg) noexcept
 
   return algorithm::UNKN;
 
-  assert (0 && "Code not reached");
+  JWT_NOT_REACHED("Code not reached");
 }
 
 /**

--- a/include/jwt/assertions.hpp
+++ b/include/jwt/assertions.hpp
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2017 Arun Muralidharan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+#ifndef CPP_JWT_ASSERTIONS_HPP
+#define CPP_JWT_ASSERTIONS_HPP
+
+#include <cassert>
+
+namespace jwt {
+
+#if defined(__clang__)
+#  define JWT_NOT_REACHED_MARKER() __builtin_unreachable()
+#elif defined(__GNUC__)
+#  if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+#    define JWT_NOT_REACHED_MARKER() __builtin_unreachable()
+#  endif
+#elif defined(_MSC_VER)
+#  define JWT_NOT_REACHED_MARKER() __assume(0)
+#endif
+
+#if defined(DEBUG)
+#  define JWT_NOT_REACHED(reason)  do { \
+                                     assert (0 && reason); \
+                                     JWT_NOT_REACHED_MARKER();        \
+                                   } while (0)
+#else
+#  define JWT_NOT_REACHED(reason)  JWT_NOT_REACHED_MARKER()
+#endif
+
+} // END namespace jwt
+
+#endif

--- a/include/jwt/jwt.hpp
+++ b/include/jwt/jwt.hpp
@@ -31,6 +31,7 @@ SOFTWARE.
 #include <cassert>
 #include <cstring>
 
+#include "jwt/assertions.hpp"
 #include "jwt/base64.hpp"
 #include "jwt/config.hpp"
 #include "jwt/algorithm.hpp"
@@ -67,7 +68,7 @@ inline enum type str_to_type(const jwt::string_view typ) noexcept
   if (!strcasecmp(typ.data(), "jwt")) return type::JWT;
   else if(!strcasecmp(typ.data(), "none")) return type::NONE;
 
-  assert (0 && "Code not reached");
+  JWT_NOT_REACHED("Code not reached");
   return type::NONE;
 }
 
@@ -82,8 +83,8 @@ inline jwt::string_view type_to_str(SCOPED_ENUM type typ)
     case type::JWT: return "JWT";
     default:        assert (0 && "Unknown type");
   };
-  __builtin_unreachable();
-  assert (0 && "Code not reached");
+
+  JWT_NOT_REACHED("Code not reached");
 }
 
 
@@ -125,8 +126,8 @@ inline jwt::string_view reg_claims_to_str(SCOPED_ENUM registered_claims claim) n
     case registered_claims::jti:        return "jti";
     default:                            assert (0 && "Not a registered claim");
   };
+  JWT_NOT_REACHED("Code not reached");
   return "";
-  assert (0 && "Code not reached");
 }
 
 /**


### PR DESCRIPTION
'__builtin_unreachable' is not available using the Microsoft C++ compiler

Replaced with a macro that inserts Windows equivalent (__assume).