### PR TITLE
Fix for error setw is not defined

### DIFF
--- a/include/jwt/impl/jwt.ipp
+++ b/include/jwt/impl/jwt.ipp
@@ -26,6 +26,7 @@ SOFTWARE.
 #include "jwt/config.hpp"
 #include "jwt/detail/meta.hpp"
 #include <algorithm>
+#include <iomanip>
 
 namespace jwt {
 


### PR DESCRIPTION
Hello!

When integration your great library to our project, we encountered the following error:

`Error message: “setw is not defined"`
 
As a fix, we've include the `<iomanip>` header file in `jwt.ipp`, and decided to make this pull request.

Kind regards