### PR TITLE
Use std::string_view if c+17 is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ Things one may have questions about
 - There is a string_view implementation. Why not use <code>boost::string_ref</code> ?
 
   Sorry, I love boost! But, do not want it to be part of dependency.
-  Having said that, I can use some MACRO to use <code>boost::string_ref</code> or C++17 string_view if available. Perhaps in future.
+  If you use C++17 or greater `std::string_view` gets used instead and `jwt::string_view` implementation does not get included.
 
 - You are not using the stack allocator or the shart string anywhere. Why to include it then ?
 

--- a/include/jwt/jwt.hpp
+++ b/include/jwt/jwt.hpp
@@ -302,8 +302,8 @@ public: // 'tors
     : alg_(alg)
     , typ_(typ)
   {
-    payload_["typ"] = type_to_str(typ_).to_string();
-    payload_["alg"] = alg_to_str(alg_).to_string();
+    payload_["typ"] = std::string(type_to_str(typ_));
+    payload_["alg"] = std::string(alg_to_str(alg_));
   }
 
   /**
@@ -331,7 +331,7 @@ public: // Exposed APIs
   void algo(SCOPED_ENUM algorithm alg)
   {
     alg_ = alg;
-    payload_["alg"] = alg_to_str(alg_).to_string();
+    payload_["alg"] = std::string(alg_to_str(alg_));
   }
 
   /**
@@ -340,7 +340,7 @@ public: // Exposed APIs
   void algo(const jwt::string_view sv)
   {
     alg_ = str_to_alg(sv.data());
-    payload_["alg"] = alg_to_str(alg_).to_string();
+    payload_["alg"] = std::string(alg_to_str(alg_));
   }
 
   /**
@@ -361,7 +361,7 @@ public: // Exposed APIs
   void typ(SCOPED_ENUM type typ) noexcept
   {
     typ_ = typ;
-    payload_["typ"] = type_to_str(typ_).to_string();
+    payload_["typ"] = std::string(type_to_str(typ_));
   }
 
   /**
@@ -370,7 +370,7 @@ public: // Exposed APIs
   void typ(const jwt::string_view sv)
   {
     typ_ = str_to_type(sv.data());
-    payload_["typ"] = type_to_str(typ_).to_string();
+    payload_["typ"] = std::string(type_to_str(typ_));
   }
 
   /**

--- a/include/jwt/string_view.hpp
+++ b/include/jwt/string_view.hpp
@@ -23,6 +23,16 @@ SOFTWARE.
 #ifndef JWT_STRING_VIEW_HPP
 #define JWT_STRING_VIEW_HPP
 
+#if __cplusplus >= 201703L
+
+#include <string_view>
+
+namespace jwt {
+  using string_view = std::string_view;
+}
+
+#else // __cplusplus >= 201703L
+
 #include <limits>
 #include <string>
 #include <cassert>
@@ -175,13 +185,6 @@ public: // Exposed APIs
   explicit operator std::basic_string<CharT, Traits, Allocator>() const
   {
     return {data_, len_};
-  }
-
-  template <typename Allocator = std::allocator<CharT>>
-  std::basic_string<CharT, Traits, Allocator>
-  to_string(const Allocator& alloc = Allocator()) const
-  {
-    return {data_, len_, alloc};
   }
 
   // NOTE: Does not throw 
@@ -371,5 +374,7 @@ using string_view = basic_string_view<char>;
 } // END namespace jwt
 
 #include "jwt/impl/string_view.ipp"
+
+#endif // __cplusplus >= 201703L
 
 #endif


### PR DESCRIPTION
If c++17 is available `jwt::string_view` is just an alias for `std::string_view`.
I also removed `.to_string` method from `jwt::string_view`, because it was not compatible with `std::string_view` and in its place used string conversion which is compatible with both `jwt::string_view` and `std::string_view`.