### PR TITLE
Fix char signedness in DMap

### DIFF
--- a/include/jwt/base64.hpp
+++ b/include/jwt/base64.hpp
@@ -153,7 +153,7 @@ public:
   constexpr DMap() = default;
 
 public:
-  constexpr char at(size_t pos) const noexcept
+  constexpr signed char at(size_t pos) const noexcept
   {
     return X_ASSERT(pos < map_.size()), map_[pos];
   }


### PR DESCRIPTION
Without this fix, the library fails to decrypt anything on platforms where `char` is unsigned by default (e.g. ARM).