### PR TITLE
Make C++17 string_view detection work with MSVC

### DIFF
--- a/include/jwt/string_view.hpp
+++ b/include/jwt/string_view.hpp
@@ -23,7 +23,7 @@ SOFTWARE.
 #ifndef JWT_STRING_VIEW_HPP
 #define JWT_STRING_VIEW_HPP
 
-#if __cplusplus >= 201703L
+#if defined(__cpp_lib_string_view)
 
 #include <string_view>
 
@@ -31,7 +31,7 @@ namespace jwt {
   using string_view = std::string_view;
 }
 
-#else // __cplusplus >= 201703L
+#else // defined(__cpp_lib_string_view)
 
 #include <limits>
 #include <string>
@@ -375,6 +375,6 @@ using string_view = basic_string_view<char>;
 
 #include "jwt/impl/string_view.ipp"
 
-#endif // __cplusplus >= 201703L
+#endif // defined(__cpp_lib_string_view)
 
 #endif


### PR DESCRIPTION
The existing method to check for support of C++17 `string_view` does not work on MSVC, see [here](https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=vs-2019)

Instead we replace with the [feature test macro](https://en.cppreference.com/w/User:D41D8CD98F/feature_testing_macros) for `string_view`, which is `__cpp_lib_string_view`. This should work on all platforms and is arguably more precise.