### PR TITLE
fix clang-cl build on windows

### DIFF
--- a/include/jwt/config.hpp
+++ b/include/jwt/config.hpp
@@ -29,7 +29,7 @@
 
 // To hack around Visual Studio error:
 // error C3431: 'algorithm': a scoped enumeration cannot be redeclared as an unscoped enumeration
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #define SCOPED_ENUM enum class
 #else
 #define SCOPED_ENUM enum


### PR DESCRIPTION
The current "hack" to fix MSVC builds and work around error C3431 prevents building with clang-cl on Windows.

This PR adds an extra check that will only activate the hack if the compiler is not clang.