### PR TITLE
Fix parsing of alg claim to be RFC compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This assertion can be used in some kind of bearer authentication mechanism that 
 
 Few good resources on this material which I found useful are:
   <a href="https://scotch.io/tutorials/the-anatomy-of-a-json-web-token">Anatomy of JWT</a>
-  <a href="https://auth0.com/learn/json-web-tokens/">Learn JWT</a> 
+  <a href="https://auth0.com/learn/json-web-tokens/">Learn JWT</a>
   <a href="https://tools.ietf.org/html/rfc7519">RFC 7519</a>
 
 
@@ -78,7 +78,7 @@ Few good resources on this material which I found useful are:
     std::cout << enc_str << std::endl;
 
     //Decode
-    auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), secret(key));
+    auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), secret(key));
     std::cout << dec_obj.header() << std::endl;
     std::cout << dec_obj.payload() << std::endl;
 
@@ -96,7 +96,7 @@ Few good resources on this material which I found useful are:
   Almost the same API, except for some ugliness here and there. But close enough!
 
   Lets take another example in which we will see to add payload claim having type other than string.
-  The <code>payload</code> function used in the above example to create <code>jwt_object</code> object can only take strings. For anything else, it will throw a compilation error. 
+  The <code>payload</code> function used in the above example to create <code>jwt_object</code> object can only take strings. For anything else, it will throw a compilation error.
 
   For adding claims having values other than string, <code>jwt_object</code> class provides <code>add_claim</code> API. We will also see few other APIs in the next example. Make sure to read the comments :).
 
@@ -109,7 +109,7 @@ Few good resources on this material which I found useful are:
     int main() {
       using namespace jwt::params;
 
-      jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"user", "admin"}})};
+      jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"user", "admin"}})};
 
       //Use add_claim API to add claim values which are
       // _not_ strings.
@@ -313,17 +313,17 @@ All the parameters are basically a function which returns an instance of a type 
     - Takes in any type which satifies the <strong>SequenceConcept</strong> (see <code>idetail::meta::is_sequence_concept</code>)
 
   ```cpp
-  jwt::decode(algorithms({"none", "hs256", "rs256"}), ...);
-  
+  jwt::decode(algorithms({"none", "HS256", "RS256"}), ...);
+
   OR
 
-  std::vector<std::string> algs{"none", "hs256", "rs256"};
+  std::vector<std::string> algs{"none", "HS256", "RS256"};
   jwt::decode(algorithms(algs), ...);
   ```
 
   - <strong>secret</strong>
 
-    Optional parameter. To be supplied only when the algorithm used is not "NONE". Else would throw/set <code>KeyNotPresentError</code> / <code>KeyNotPresent</code> exception/error.
+    Optional parameter. To be supplied only when the algorithm used is not "none". Else would throw/set <code>KeyNotPresentError</code> / <code>KeyNotPresent</code> exception/error.
 
   - <strong>leeway</strong>
 
@@ -365,7 +365,7 @@ All the parameters are basically a function which returns an instance of a type 
 
   - <strong>validate_jti</strong>
 
-    Optional parameter. 
+    Optional parameter.
     Takes a boolean value.
     Validates the JTI claim. Only checks for the presence of the claim. If  not throws or sets <code>InvalidJTIError</code> or <code>InvalidJTI</code>.
 
@@ -394,7 +394,7 @@ For the registered claim types the library assumes specific data types for the c
 
 
 ## Advanced Examples
-We will see few complete examples which makes use of error code checks and exception handling. 
+We will see few complete examples which makes use of error code checks and exception handling.
 The examples are taken from the "tests" section. Users are requested to checkout the tests to find out more ways to use this library.
 
 Expiration verification example (uses error_code):
@@ -406,7 +406,7 @@ Expiration verification example (uses error_code):
 int main() {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("exp", std::chrono::system_clock::now() - std::chrono::seconds{1})
      ;
@@ -415,7 +415,7 @@ int main() {
   auto enc_str = obj.signature(ec);
   assert (!ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"), verify(true));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"), verify(true));
   assert (ec);
   assert (ec.value() == static_cast<int>(jwt::VerificationErrc::TokenExpired));
 
@@ -432,7 +432,7 @@ Expiration verification example (uses exception):
 int main() {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
 
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("exp", std::chrono::system_clock::now() - std::chrono::seconds{1})
@@ -441,7 +441,7 @@ int main() {
   auto enc_str = obj.signature();
 
   try {
-    auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), secret("secret"), verify(true));
+    auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), secret("secret"), verify(true));
   } catch (const jwt::TokenExpiredError& e) {
     //Handle Token expired exception here
     //...
@@ -450,7 +450,7 @@ int main() {
     //...
   } catch (const jwt::DecodeError& e) {
     //Handle all kinds of other decode errors
-    //... 
+    //...
   } catch (const jwt::VerificationError& e) {
     // Handle the base verification error.
     //NOTE: There are other derived types of verification errors
@@ -472,13 +472,13 @@ Invalid issuer test(uses error_code):
 int main() {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}})};
 
   std::error_code ec;
   auto enc_str = obj.signature(ec);
   assert (!ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"), issuer("arun.muralidharan"));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"), issuer("arun.muralidharan"));
   assert (ec);
 
   assert (ec.value() == static_cast<int>(jwt::VerificationErrc::InvalidIssuer));
@@ -566,7 +566,7 @@ The error codes are divided into different categories:
     TypeConversionError,
   };
   ```
-  
+
 <strong>Exceptions:</strong>
 There are exception types created for almost all the error codes above.
 
@@ -588,7 +588,7 @@ There are exception types created for almost all the error codes above.
 
   - KeyNotPresentError
 
-    Thrown if key/secret is not passed in with the decode API if the algorithm used is something other than "NONE".
+    Thrown if key/secret is not passed in with the decode API if the algorithm used is something other than "none".
 
 - VerificationError
 
@@ -644,7 +644,7 @@ int main() {
 
   auto dec_obj = jwt::decode(enc_str, algorithms({"none"}), ec, verify(false));
 
-  // Should not be a hard error in general 
+  // Should not be a hard error in general
   assert (ec.value() == static_cast<int>(jwt::AlgorithmErrc::NoneAlgorithmUsed));
 }
 ```

--- a/examples/simple_ex2.cc
+++ b/examples/simple_ex2.cc
@@ -6,7 +6,7 @@
 int main() {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"user", "admin"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"user", "admin"}})};
 
   //Use add_claim API to add claim values which are
   // _not_ strings.

--- a/examples/simple_ex3_rsa.cc
+++ b/examples/simple_ex3_rsa.cc
@@ -44,7 +44,7 @@ int main() {
 
   auto priv_key = read_from_file(priv_key_path);
 
-  jwt::jwt_object obj{algorithm("rs256"), secret(priv_key), payload({{"user", "admin"}})};
+  jwt::jwt_object obj{algorithm("RS256"), secret(priv_key), payload({{"user", "admin"}})};
 
   //Use add_claim API to add claim values which are
   // _not_ strings.
@@ -76,7 +76,7 @@ int main() {
     return 1;
   }
 
-  auto dec_obj = jwt::decode(sign, algorithms({"rs256"}), verify(false), secret(pub_key));
+  auto dec_obj = jwt::decode(sign, algorithms({"RS256"}), verify(false), secret(pub_key));
 
   return 0;
 }

--- a/include/jwt/algorithm.hpp
+++ b/include/jwt/algorithm.hpp
@@ -57,7 +57,7 @@ using sign_result_t = std::pair<std::string, std::error_code>;
 /// The result type of verification function
 using verify_result_t = std::pair<bool, std::error_code>;
 /// The function pointer type for the signing function
-using sign_func_t   = sign_result_t (*) (const jwt::string_view key, 
+using sign_func_t   = sign_result_t (*) (const jwt::string_view key,
                                          const jwt::string_view data);
 /// The function pointer type for the verifying function
 using verify_func_t = verify_result_t (*) (const jwt::string_view key,
@@ -235,7 +235,7 @@ inline jwt::string_view alg_to_str(SCOPED_ENUM algorithm alg) noexcept
     case algorithm::ES384: return "ES384";
     case algorithm::ES512: return "ES512";
     case algorithm::TERM:  return "TERM";
-    case algorithm::NONE:  return "NONE";
+    case algorithm::NONE:  return "none";
     case algorithm::UNKN:  return "UNKN";
     default:               assert (0 && "Unknown Algorithm");
   };
@@ -249,18 +249,18 @@ inline jwt::string_view alg_to_str(SCOPED_ENUM algorithm alg) noexcept
  */
 inline SCOPED_ENUM algorithm str_to_alg(const jwt::string_view alg) noexcept
 {
-  if (!alg.length()) return algorithm::NONE;
+  if (!alg.length()) return algorithm::UNKN;
 
   if (!strcasecmp(alg.data(), "none"))  return algorithm::NONE;
-  if (!strcasecmp(alg.data(), "hs256")) return algorithm::HS256;
-  if (!strcasecmp(alg.data(), "hs384")) return algorithm::HS384;
-  if (!strcasecmp(alg.data(), "hs512")) return algorithm::HS512;
-  if (!strcasecmp(alg.data(), "rs256")) return algorithm::RS256;
-  if (!strcasecmp(alg.data(), "rs384")) return algorithm::RS384;
-  if (!strcasecmp(alg.data(), "rs512")) return algorithm::RS512;
-  if (!strcasecmp(alg.data(), "es256")) return algorithm::ES256;
-  if (!strcasecmp(alg.data(), "es384")) return algorithm::ES384;
-  if (!strcasecmp(alg.data(), "es512")) return algorithm::ES512;
+  if (!strcasecmp(alg.data(), "HS256")) return algorithm::HS256;
+  if (!strcasecmp(alg.data(), "HS384")) return algorithm::HS384;
+  if (!strcasecmp(alg.data(), "HS512")) return algorithm::HS512;
+  if (!strcasecmp(alg.data(), "RS256")) return algorithm::RS256;
+  if (!strcasecmp(alg.data(), "RS384")) return algorithm::RS384;
+  if (!strcasecmp(alg.data(), "RS512")) return algorithm::RS512;
+  if (!strcasecmp(alg.data(), "ES256")) return algorithm::ES256;
+  if (!strcasecmp(alg.data(), "ES384")) return algorithm::ES384;
+  if (!strcasecmp(alg.data(), "ES512")) return algorithm::ES512;
 
   return algorithm::UNKN;
 
@@ -385,14 +385,14 @@ struct HMACSign
    *  Returns:
    *    verify_result_t
    *    verify_result_t::first set to true if verification succeeds.
-   *    false otherwise. 
+   *    false otherwise.
    *    verify_result_t::second set to relevant error if verification fails.
    *
    *  Exceptions:
    *    Any allocation failure will result in jwt::MemoryAllocationException
    *    being thrown.
    */
-  static verify_result_t 
+  static verify_result_t
   verify(const jwt::string_view key, const jwt::string_view head, const jwt::string_view sign);
 
 };
@@ -405,10 +405,10 @@ struct HMACSign
  * PEM based algorithms.
  *
  * The signing and verification APIs are
- * basically no-op except that they would 
+ * basically no-op except that they would
  * set the relevant error code.
  *
- * NOTE: error_code would be set in the case 
+ * NOTE: error_code would be set in the case
  * of usage of NONE algorithm.
  * Users of this API are expected to check for
  * the case explicitly.
@@ -534,7 +534,7 @@ private:
   /**
    */
   static int ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s)
-  { 
+  {
     if (r == nullptr || s == nullptr) return 0;
 
     BN_clear_free(sig->r);

--- a/include/jwt/test/test_jwt_decode.cc
+++ b/include/jwt/test/test_jwt_decode.cc
@@ -21,7 +21,7 @@ void basic_decode_test()
   using namespace jwt::params;
 
   std::cout << "DECODE: \n";
-  jwt::decode(res, algorithms({"none", "hs256"}), ec, verify(false), secret("secret"));
+  jwt::decode(res, algorithms({"none", "HS256"}), ec, verify(false), secret("secret"));
 }
 
 int main() {

--- a/include/jwt/test/test_jwt_object.cc
+++ b/include/jwt/test/test_jwt_object.cc
@@ -11,7 +11,7 @@ void basic_jwt_object_test()
   using namespace jwt::params;
   jwt::jwt_object obj(payload({
                                 {"a", "b"},
-                                {"c", "d"} 
+                                {"c", "d"}
                               }));
 
   //check with std::map
@@ -20,7 +20,7 @@ void basic_jwt_object_test()
   m["c"] = "d";
 
   jwt::jwt_object obj1{payload(m)};
-  
+
   auto obj2 = std::move(obj1);
 
   std::cout << obj2.payload() << std::endl;
@@ -43,23 +43,23 @@ void basic_jwt_object_test()
   std::cout << obj3.payload() << std::endl;
 
   obj3.secret("secret");
-  obj3.header().algo("hs256");
+  obj3.header().algo("HS256");
 
-  auto dec_obj = jwt::decode(obj3.signature(), algorithms({"hs256"}), secret("secret"));
+  auto dec_obj = jwt::decode(obj3.signature(), algorithms({"HS256"}), secret("secret"));
 }
 
 void jwt_object_pem_test()
 {
   using namespace jwt::params;
 
-  std::string pub_key = 
+  std::string pub_key =
     R"(-----BEGIN PUBLIC KEY-----
 MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEomxC9ycc8AkXSwWQpu1kN5Fmgy/sD/KJ
 qN3tlSZmUEZ3w3c6KYJfK97PMOSZQaUdeydBoq/IOglQQOj8zLqubq5IpaaUiDQ5
 0eJg79PvXuLiVUH98cBL/o8sDVB/sGzz
 -----END PUBLIC KEY-----)";
 
-  std::string priv_key = 
+  std::string priv_key =
 R"(-----BEGIN EC PRIVATE KEY-----
 MIGkAgEBBDBeLCgapjZmvTatMHaYX3A02+0Ys3Tr8kda+E9DFnmCSiCOEig519fT
 13edeU8YdDugBwYFK4EEACKhZANiAASibEL3JxzwCRdLBZCm7WQ3kWaDL+wP8omo
@@ -79,10 +79,10 @@ MIGkAgEBBDBeLCgapjZmvTatMHaYX3A02+0Ys3Tr8kda+E9DFnmCSiCOEig519fT
      ;
 
   std::cout << "pem sign " << obj.signature() << std::endl;
-  std::cout << "Get claim value for exp: " << 
+  std::cout << "Get claim value for exp: " <<
     obj.payload().get_claim_value<uint64_t>("exp") << std::endl;
 
-  auto dec_obj = jwt::decode(obj.signature(), algorithms({"es256"}), secret(pub_key));
+  auto dec_obj = jwt::decode(obj.signature(), algorithms({"ES256"}), secret(pub_key));
   std::cout << dec_obj.payload() << std::endl;
 }
 

--- a/tests/test_jwt_decode.cc
+++ b/tests/test_jwt_decode.cc
@@ -5,11 +5,11 @@
 TEST (DecodeTest, InvalidFinalDotForNoneAlg)
 {
   using namespace jwt::params;
-  const char* inv_enc_str = 
+  const char* inv_enc_str =
     "eyJhbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ";
 
   std::error_code ec;
-  auto obj = jwt::decode(inv_enc_str, algorithms({"none", "hs256"}), ec);
+  auto obj = jwt::decode(inv_enc_str, algorithms({"none", "HS256"}), ec);
 
   ASSERT_TRUE (ec);
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::DecodeErrc::SignatureFormatError));
@@ -18,7 +18,7 @@ TEST (DecodeTest, InvalidFinalDotForNoneAlg)
 TEST (DecodeTest, DecodeNoneAlgSign)
 {
   using namespace jwt::params;
-  const char* enc_str = 
+  const char* enc_str =
     "eyJhbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjo0NTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ.";
 
   std::error_code ec;
@@ -45,7 +45,7 @@ TEST (DecodeTest, DecodeWrongAlgo)
     "eyJhbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ.";
 
   std::error_code ec;
-  auto obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret(""), verify(true));
+  auto obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret(""), verify(true));
   EXPECT_TRUE (ec);
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::VerificationErrc::InvalidAlgorithm));
 }
@@ -58,7 +58,7 @@ TEST (DecodeTest, DecodeInvalidHeader)
     "ehbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ.";
 
   std::error_code ec;
-  auto obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret(""), verify(true));
+  auto obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret(""), verify(true));
   ASSERT_TRUE (ec);
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::DecodeErrc::JsonParseError));
 
@@ -72,7 +72,7 @@ TEST (DecodeTest, DecodeEmptyHeader)
     ".eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ.";
 
   std::error_code ec;
-  auto obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret(""), verify(true));
+  auto obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret(""), verify(true));
   ASSERT_TRUE (ec);
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::DecodeErrc::JsonParseError));
 
@@ -82,7 +82,7 @@ TEST (DecodeTest, DecodeInvalidPayload)
 {
   using namespace jwt::params;
 
-  const char* enc_str = 
+  const char* enc_str =
     "eyJhbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyfhuWcikiJyaWZ0LmlvIiwiZXhwIsexNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ.";
 
   std::error_code ec;
@@ -95,14 +95,14 @@ TEST (DecodeTest, DecodeInvalidPayload)
 TEST (DecodeTest, DecodeHS256)
 {
   using namespace jwt::params;
-  
+
   const char* enc_str =
    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
    "eyJpYXQiOjE1MTM4NjIzNzEsImlkIjoiYS1iLWMtZC1lLWYtMS0yLTMiLCJpc3MiOiJhcnVuLm11cmFsaWRoYXJhbiIsInN1YiI6ImFkbWluIn0."
    "jk7bRQKTLvs1RcuvMc2B_rt6WBYPoVPirYi_QRBPiuk";
 
   std::error_code ec;
-  auto obj = jwt::decode(enc_str, algorithms({"none", "hs256"}), ec, verify(false), secret("secret"));
+  auto obj = jwt::decode(enc_str, algorithms({"none", "HS256"}), ec, verify(false), secret("secret"));
   ASSERT_FALSE (ec);
 
   EXPECT_TRUE (obj.has_claim("iss"));
@@ -119,13 +119,13 @@ TEST (DecodeTest, SecretKeyNotPassed)
 {
   using namespace jwt::params;
 
-  const char* enc_str = 
+  const char* enc_str =
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
     "eyJpYXQiOjE1MTM4NjIzNzEsImlkIjoiYS1iLWMtZC1lLWYtMS0yLTMiLCJpc3MiOiJhcnVuLm11cmFsaWRoYXJhbiIsInN1YiI6ImFkbWluIn0."
     "jk7bRQKTLvs1RcuvMc2B_rt6WBYPoVPirYi_QRBPiuk";
 
   std::error_code ec;
-  auto obj = jwt::decode(enc_str, algorithms({"none", "hs256"}), ec, verify(true));
+  auto obj = jwt::decode(enc_str, algorithms({"none", "HS256"}), ec, verify(true));
 
   ASSERT_TRUE (ec);
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::DecodeErrc::KeyNotPresent));
@@ -143,7 +143,7 @@ TEST (DecodeTest, DecodeHS384)
   const jwt::string_view key = "0123456789abcdefghijklmnopqrstuvwxyz";
 
   std::error_code ec;
-  auto obj = jwt::decode(enc_str, algorithms({"none", "hs384"}), ec, verify(false), secret(key));
+  auto obj = jwt::decode(enc_str, algorithms({"none", "HS384"}), ec, verify(false), secret(key));
   ASSERT_FALSE (ec);
 
   EXPECT_TRUE (obj.has_claim("sub"));
@@ -154,7 +154,7 @@ TEST (DecodeTest, DecodeHS512)
 {
   using namespace jwt::params;
 
-  const char* enc_str = 
+  const char* enc_str =
   "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9."
   "eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ."
   "vQ-1JSFN1kPjUI3URP6AFK5z8V7xLhyhw-76QWhQg9Xcy-IgrJ-bCTYLBjgaprrcEWwpSnBQnP3QnIxYK0HEaQ";
@@ -162,7 +162,7 @@ TEST (DecodeTest, DecodeHS512)
   const jwt::string_view key = "00112233445566778899";
 
   std::error_code ec;
-  auto obj = jwt::decode(enc_str, algorithms({"none", "hs384", "hs512"}), ec, verify(false), secret(key));
+  auto obj = jwt::decode(enc_str, algorithms({"none", "HS384", "HS512"}), ec, verify(false), secret(key));
 
   ASSERT_FALSE (ec);
 
@@ -174,13 +174,13 @@ TEST (DecodeTest, TypHeaderMiss)
 {
   using namespace jwt::params;
 
-  const char* enc_str = 
+  const char* enc_str =
     "eyJhbGciOiJIUzI1NiJ9."
     "eyJleHAiOjE1MzM0NjE1NTMsImlhdCI6MTUxMzg2MjM3MSwiaWQiOiJhLWItYy1kLWUtZi0xLTItMyIsImlzcyI6ImFydW4ubXVyYWxpZGhhcmFuIiwic3ViIjoiYWRtaW4ifQ."
     "pMWBLSWl1p4V958lfe_6ZhvgFMOQv9Eq5mlndVKFKkA";
 
   std::error_code ec;
-  auto obj = jwt::decode(enc_str, algorithms({"none", "hs256"}), ec, verify(false));
+  auto obj = jwt::decode(enc_str, algorithms({"none", "HS256"}), ec, verify(false));
   std::cout << "Decode header: " << obj.header() << std::endl;
 
   EXPECT_FALSE (ec);

--- a/tests/test_jwt_decode_verifiy.cc
+++ b/tests/test_jwt_decode_verifiy.cc
@@ -9,7 +9,7 @@ TEST (DecodeVerify, BeforeExpiryTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("exp", std::chrono::system_clock::now() + std::chrono::seconds{10})
      ;
@@ -19,7 +19,7 @@ TEST (DecodeVerify, BeforeExpiryTest)
 
   ASSERT_FALSE (ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"), verify(true));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"), verify(true));
   ASSERT_FALSE (ec);
 }
 
@@ -27,7 +27,7 @@ TEST (DecodeVerify, AfterExpiryTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("exp", std::chrono::system_clock::now() - std::chrono::seconds{1})
      ;
@@ -36,7 +36,7 @@ TEST (DecodeVerify, AfterExpiryTest)
   auto enc_str = obj.signature(ec);
   ASSERT_FALSE (ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"), verify(true));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"), verify(true));
   ASSERT_TRUE (ec);
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::VerificationErrc::TokenExpired));
 }
@@ -45,7 +45,7 @@ TEST (DecodeVerify, AfterExpiryWithLeeway)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("exp", std::chrono::system_clock::now() - std::chrono::seconds{1})
      ;
@@ -54,7 +54,7 @@ TEST (DecodeVerify, AfterExpiryWithLeeway)
   auto enc_str = obj.signature(ec);
   ASSERT_FALSE (ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"), verify(true), leeway(2));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"), verify(true), leeway(2));
   ASSERT_FALSE (ec);
 }
 
@@ -62,7 +62,7 @@ TEST (DecodeVerify, ValidIssuerTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("sub", "test")
      ;
@@ -71,7 +71,7 @@ TEST (DecodeVerify, ValidIssuerTest)
   auto enc_str = obj.signature(ec);
   ASSERT_FALSE (ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"), issuer("arun.muralidharan"));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"), issuer("arun.muralidharan"));
   ASSERT_FALSE (ec);
 }
 
@@ -79,12 +79,12 @@ TEST (DecodeVerify, InvalidIssuerTest_1)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}})};
   std::error_code ec;
   auto enc_str = obj.signature(ec);
   ASSERT_FALSE (ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"), issuer("arun.muralidharan"));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"), issuer("arun.muralidharan"));
   ASSERT_TRUE (ec);
 
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::VerificationErrc::InvalidIssuer));
@@ -94,14 +94,14 @@ TEST (DecodeVerify, InvalidIssuerTest_2)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}})};
   obj.add_claim("iss", "arun.muralidharan");
 
   std::error_code ec;
   auto enc_str = obj.signature(ec);
   ASSERT_FALSE (ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"), issuer("arun.murali"));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"), issuer("arun.murali"));
   ASSERT_TRUE (ec);
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::VerificationErrc::InvalidIssuer));
 }
@@ -110,14 +110,14 @@ TEST (DecodeVerify, NotImmatureSignatureTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}})};
   obj.add_claim(jwt::registered_claims::not_before, std::chrono::system_clock::now() - std::chrono::seconds{10});
 
   std::error_code ec;
   auto enc_str = obj.signature(ec);
   ASSERT_FALSE (ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"));
   ASSERT_FALSE (ec);
 }
 
@@ -125,14 +125,14 @@ TEST (DecodeVerify, ImmatureSignatureTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}})};
   obj.add_claim(jwt::registered_claims::not_before, std::chrono::system_clock::now() + std::chrono::seconds{10});
 
   std::error_code ec;
   auto enc_str = obj.signature(ec);
   ASSERT_FALSE (ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"));
   ASSERT_TRUE (ec);
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::VerificationErrc::ImmatureSignature));
 }
@@ -141,14 +141,14 @@ TEST (DecodeVerify, ImmatureSignatureTestWithLeeway)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}})};
   obj.add_claim(jwt::registered_claims::not_before, std::chrono::system_clock::now() + std::chrono::seconds{10});
 
   std::error_code ec;
   auto enc_str = obj.signature(ec);
   ASSERT_FALSE (ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"), leeway(10));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"), leeway(10));
   ASSERT_FALSE (ec);
 }
 
@@ -156,13 +156,13 @@ TEST (DecodeVerify, InvalidAudienceTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}, {"aud", "www"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}, {"aud", "www"}})};
 
   std::error_code ec;
   auto enc_str = obj.signature(ec);
   ASSERT_FALSE (ec);
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"), aud("ww"));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"), aud("ww"));
   ASSERT_TRUE (ec);
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::VerificationErrc::InvalidAudience));
 }
@@ -171,13 +171,13 @@ TEST (DecodeVerify, InvalidIATTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}, {"aud", "www"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}, {"aud", "www"}})};
 
   obj.add_claim("iat", "what?");
   auto enc_str = obj.signature();
 
   std::error_code ec;
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), ec, secret("secret"), validate_iat(true));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), ec, secret("secret"), validate_iat(true));
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::VerificationErrc::TypeConversionError));
 }
 
@@ -186,11 +186,11 @@ TEST (DecodeVerify, InvalidSignatureTest)
   using namespace jwt::params;
 
   std::error_code ec;
-  auto dec_obj = jwt::decode("", algorithms({"hs256"}), ec, secret("secret"), validate_iat(true));
+  auto dec_obj = jwt::decode("", algorithms({"HS256"}), ec, secret("secret"), validate_iat(true));
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::DecodeErrc::SignatureFormatError));
 
   ec.clear();
-  dec_obj = jwt::decode("abcdsdfhbsdhjfbsdj.", algorithms({"hs256"}), ec, secret("secret"), validate_iat(true));
+  dec_obj = jwt::decode("abcdsdfhbsdhjfbsdj.", algorithms({"HS256"}), ec, secret("secret"), validate_iat(true));
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::DecodeErrc::SignatureFormatError));
 }
 

--- a/tests/test_jwt_decode_verifiy_with_exception.cc
+++ b/tests/test_jwt_decode_verifiy_with_exception.cc
@@ -9,28 +9,28 @@ TEST (DecodeVerifyExp, BeforeExpiryTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("exp", std::chrono::system_clock::now() + std::chrono::seconds{10})
      ;
 
   auto enc_str = obj.signature();
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), secret("secret"), verify(true));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), secret("secret"), verify(true));
 }
 
 TEST (DecodeVerifyExp, AfterExpiryTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("exp", std::chrono::system_clock::now() - std::chrono::seconds{1})
      ;
 
   auto enc_str = obj.signature();
 
-  EXPECT_THROW (jwt::decode(enc_str, algorithms({"hs256"}), secret("secret"), verify(true)),
+  EXPECT_THROW (jwt::decode(enc_str, algorithms({"HS256"}), secret("secret"), verify(true)),
                 jwt::TokenExpiredError);
 
 }
@@ -39,13 +39,13 @@ TEST (DecodeVerifyExp, AfterExpiryWithLeeway)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("exp", std::chrono::system_clock::now() - std::chrono::seconds{1})
      ;
 
   auto enc_str = obj.signature();
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), secret("secret"), verify(true), leeway(2));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), secret("secret"), verify(true), leeway(2));
   (void)dec_obj;
 }
 
@@ -53,14 +53,14 @@ TEST (DecodeVerifyExp, ValidIssuerTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("sub", "test")
      ;
 
   auto enc_str = obj.signature();
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), secret("secret"), issuer("arun.muralidharan"));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), secret("secret"), issuer("arun.muralidharan"));
   (void)dec_obj;
 }
 
@@ -68,10 +68,10 @@ TEST (DecodeVerifyExp, InvalidIssuerTest_1)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}})};
   auto enc_str = obj.signature();
 
-  EXPECT_THROW (jwt::decode(enc_str, algorithms({"hs256"}), secret("secret"), issuer("arun.muralidharan")),
+  EXPECT_THROW (jwt::decode(enc_str, algorithms({"HS256"}), secret("secret"), issuer("arun.muralidharan")),
                 jwt::InvalidIssuerError);
 
 }
@@ -80,12 +80,12 @@ TEST (DecodeVerifyExp, InvalidIssuerTest_2)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}})};
   obj.add_claim("iss", "arun.muralidharan");
 
   auto enc_str = obj.signature();
 
-  EXPECT_THROW (jwt::decode(enc_str, algorithms({"hs256"}), secret("secret"), issuer("arun.murali")),
+  EXPECT_THROW (jwt::decode(enc_str, algorithms({"HS256"}), secret("secret"), issuer("arun.murali")),
                 jwt::InvalidIssuerError);
 }
 
@@ -93,12 +93,12 @@ TEST (DecodeVerifyExp, NotImmatureSignatureTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}})};
   obj.add_claim(jwt::registered_claims::not_before, std::chrono::system_clock::now() - std::chrono::seconds{10});
 
   auto enc_str = obj.signature();
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), secret("secret"));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), secret("secret"));
   (void)dec_obj;
 }
 
@@ -106,12 +106,12 @@ TEST (DecodeVerifyExp, ImmatureSignatureTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}})};
   obj.add_claim(jwt::registered_claims::not_before, std::chrono::system_clock::now() + std::chrono::seconds{10});
 
   auto enc_str = obj.signature();
 
-  EXPECT_THROW (jwt::decode(enc_str, algorithms({"hs256"}), secret("secret")),
+  EXPECT_THROW (jwt::decode(enc_str, algorithms({"HS256"}), secret("secret")),
                 jwt::ImmatureSignatureError);
 }
 
@@ -119,12 +119,12 @@ TEST (DecodeVerifyExp, ImmatureSignatureTestWithLeeway)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}})};
   obj.add_claim(jwt::registered_claims::not_before, std::chrono::system_clock::now() + std::chrono::seconds{10});
 
   auto enc_str = obj.signature();
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"hs256"}), secret("secret"), leeway(10));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"HS256"}), secret("secret"), leeway(10));
   (void)dec_obj;
 }
 
@@ -132,11 +132,11 @@ TEST (DecodeVerifyExp, InvalidAudienceTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}, {"aud", "www"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}, {"aud", "www"}})};
 
   auto enc_str = obj.signature();
 
-  EXPECT_THROW (jwt::decode(enc_str, algorithms({"hs256"}), secret("secret"), aud("ww")),
+  EXPECT_THROW (jwt::decode(enc_str, algorithms({"HS256"}), secret("secret"), aud("ww")),
                 jwt::InvalidAudienceError);
 }
 
@@ -147,7 +147,7 @@ TEST (DecodeVerifyExp, InvalidSignatureTest)
   const char* inv_enc_str =
     "eyJhbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ";
 
-  EXPECT_THROW (jwt::decode(inv_enc_str, algorithms({"none", "hs256"})),
+  EXPECT_THROW (jwt::decode(inv_enc_str, algorithms({"none", "HS256"})),
                 jwt::SignatureFormatError);
 }
 
@@ -160,7 +160,7 @@ TEST (DecodeVerifyExp, KeyNotPresentTest)
     "eyJpYXQiOjE1MTM4NjIzNzEsImlkIjoiYS1iLWMtZC1lLWYtMS0yLTMiLCJpc3MiOiJhcnVuLm11cmFsaWRoYXJhbiIsInN1YiI6ImFkbWluIn0."
     "jk7bRQKTLvs1RcuvMc2B_rt6WBYPoVPirYi_QRBPiuk";
 
-  EXPECT_THROW (jwt::decode(enc_str, algorithms({"none", "hs256"}), verify(true)),
+  EXPECT_THROW (jwt::decode(enc_str, algorithms({"none", "HS256"}), verify(true)),
                 jwt::KeyNotPresentError);
 }
 
@@ -168,11 +168,11 @@ TEST (DecodeVerifyExp, InvalidSubjectTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret"), payload({{"sub", "test"}, {"aud", "www"}})};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret"), payload({{"sub", "test"}, {"aud", "www"}})};
 
   auto enc_str = obj.signature();
 
-  EXPECT_THROW (jwt::decode(enc_str, algorithms({"hs256"}), secret("secret"), sub("TEST")),
+  EXPECT_THROW (jwt::decode(enc_str, algorithms({"HS256"}), secret("secret"), sub("TEST")),
                 jwt::InvalidSubjectError);
 }
 

--- a/tests/test_jwt_encode.cc
+++ b/tests/test_jwt_encode.cc
@@ -8,7 +8,7 @@ TEST (EncodeTest, TestRemoveClaim)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
 
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("sub", "admin")
@@ -29,7 +29,7 @@ TEST (EncodeTest, TestRemoveTypHeader)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
 
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("sub", "admin")
@@ -49,12 +49,12 @@ TEST (EncodeTest, StrEncodeHS256_1)
 {
   using namespace jwt::params;
 
-  const char* expected_sign = 
+  const char* expected_sign =
    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
    "eyJpYXQiOjE1MTM4NjIzNzEsImlkIjoiYS1iLWMtZC1lLWYtMS0yLTMiLCJpc3MiOiJhcnVuLm11cmFsaWRoYXJhbiIsInN1YiI6ImFkbWluIn0."
    "jk7bRQKTLvs1RcuvMc2B_rt6WBYPoVPirYi_QRBPiuk";
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
 
   obj.add_claim("iss", "arun.muralidharan")
      .add_claim("sub", "admin")
@@ -102,7 +102,7 @@ TEST (EncodeTest, StrEncodeNONE)
 {
   using namespace jwt::params;
 
-  const char* expected_sign = 
+  const char* expected_sign =
     "eyJhbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ.";
 
   jwt::jwt_object obj{algorithm("none")};
@@ -124,7 +124,7 @@ TEST (EncodeTest, StrEncodeHS256WithKey)
 {
   using namespace jwt::params;
 
-  const char* expected_sign = 
+  const char* expected_sign =
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
     "eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ."
     "W6t7mUX6ZJwOVTsVhHSKyBSwi0wnibobdsk456wSmJg";
@@ -149,7 +149,7 @@ TEST (EncodeTest, StrEncodeHS384WithKey)
 
   using namespace jwt::params;
 
-  const char* expected_sign = 
+  const char* expected_sign =
     "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9."
     "eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ."
     "cGN4FZCe9Y2c1dA-jP71IXGnYbJRc4OaUTa5m7N7ybF5h6wBwxWQ-pdcxYchjDBL";
@@ -173,7 +173,7 @@ TEST (EncodeTest, StrEncodeHS512WithKey)
 {
   using namespace jwt::params;
 
-  const char* expected_sign = 
+  const char* expected_sign =
     "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9."
     "eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ."
     "vQ-1JSFN1kPjUI3URP6AFK5z8V7xLhyhw-76QWhQg9Xcy-IgrJ-bCTYLBjgaprrcEWwpSnBQnP3QnIxYK0HEaQ";
@@ -199,7 +199,7 @@ TEST (EncodeTest, StrEncodeChangeAlg)
 {
   using namespace jwt::params;
 
-  const char* expected_none_sign = 
+  const char* expected_none_sign =
     "eyJhbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyJhdWQiOiJyaWZ0LmlvIiwiZXhwIjoxNTEzODYzMzcxLCJzdWIiOiJub3RoaW5nIG11Y2gifQ.";
 
   jwt::string_view key = "00112233445566778899";
@@ -242,7 +242,7 @@ TEST (EncodeTest, StrEncodeNoneAlgWithKey)
   const jwt::string_view secret1 = "abcdefghijklmnopqrstuvwxyz";
   const jwt::string_view secret2 = "0123456789qwertybabe";
 
-  jwt::jwt_object obj{algorithm("NONE"),
+  jwt::jwt_object obj{algorithm("none"),
                       payload({{"iss", "arn-ml"}}),
                       secret(secret1)};
 
@@ -261,7 +261,7 @@ TEST (EncodeTest, OverwriteClaimsTest)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("NONE"),
+  jwt::jwt_object obj{algorithm("none"),
                       payload({
                                 {"iss", "arn-ml"},
                                 {"x-pld1", "data1"},
@@ -312,7 +312,7 @@ TEST (EncodeTest, HeaderParamTest)
   std::cout << dec_obj.header() << std::endl;
 }
 
-int main(int argc, char **argv) 
+int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/tests/test_jwt_es.cc
+++ b/tests/test_jwt_es.cc
@@ -53,7 +53,7 @@ TEST (ESAlgo, ES256EncodingDecodingTest)
   key = read_from_file(EC384_PUB_KEY);
   ASSERT_TRUE (key.length());
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"es256"}), ec, verify(false), secret(key));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"ES256"}), ec, verify(false), secret(key));
   EXPECT_FALSE (ec);
 
   EXPECT_EQ (dec_obj.header().algo(), jwt::algorithm::ES256);
@@ -83,7 +83,7 @@ TEST (ESAlgo, ES384EncodingDecodingTest)
   key = read_from_file(EC384_PUB_KEY);
   ASSERT_TRUE (key.length());
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"es384"}), verify(false), secret(key));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"ES384"}), verify(false), secret(key));
 
   EXPECT_EQ (dec_obj.header().algo(), jwt::algorithm::ES384);
 }
@@ -107,7 +107,7 @@ TEST (ESAlgo, ES512EncodingDecodingTest)
   key = read_from_file(EC384_PUB_KEY);
   ASSERT_TRUE (key.length());
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"es512"}), verify(false), secret(key));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"ES512"}), verify(false), secret(key));
 
   EXPECT_EQ (dec_obj.header().algo(), jwt::algorithm::ES512);
 }
@@ -131,7 +131,7 @@ TEST (ESAlgo, ES384EncodingDecodingValidTest)
   key = read_from_file(EC384_PUB_KEY);
   ASSERT_TRUE (key.length());
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"es384"}), verify(true), secret(key));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"ES384"}), verify(true), secret(key));
 
   EXPECT_EQ (dec_obj.header().algo(), jwt::algorithm::ES384);
   EXPECT_TRUE (dec_obj.has_claim("exp"));
@@ -139,11 +139,11 @@ TEST (ESAlgo, ES384EncodingDecodingValidTest)
 
   std::map<std::string, std::string> keystore{{"arun.muralidharan", key}};
 
-  auto l = [&keystore](const jwt::jwt_payload& payload){ 
+  auto l = [&keystore](const jwt::jwt_payload& payload){
     auto iss = payload.get_claim_value<std::string>("iss");
     return keystore[iss];
   };
-  auto dec_obj2 = jwt::decode(enc_str, algorithms({"es384"}), verify(true), secret(l));
+  auto dec_obj2 = jwt::decode(enc_str, algorithms({"ES384"}), verify(true), secret(l));
   EXPECT_EQ (dec_obj2.header().algo(), jwt::algorithm::ES384);
 }
 

--- a/tests/test_jwt_object.cc
+++ b/tests/test_jwt_object.cc
@@ -17,7 +17,7 @@ TEST (ObjectTest, MoveConstructor)
 {
   using namespace jwt::params;
 
-  jwt::jwt_object obj{algorithm("hs256"), secret("secret")};
+  jwt::jwt_object obj{algorithm("HS256"), secret("secret")};
 
   obj.add_claim("iss", "arun.muralidharan");
 
@@ -28,7 +28,7 @@ TEST (ObjectTest, MoveConstructor)
   EXPECT_TRUE(wrapper.object.payload().has_claim_with_value("iss", "arun.muralidharan"));
 }
 
-int main(int argc, char **argv) 
+int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/tests/test_jwt_rsa.cc
+++ b/tests/test_jwt_rsa.cc
@@ -40,7 +40,7 @@ TEST (RSAAlgo, RSA256EncodingDecodingTest)
 {
   using namespace jwt::params;
 
-  const char* expected_sign = 
+  const char* expected_sign =
     "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhbGwiLCJleHAiOjE1MTM4NjIzNzEsImlzcyI6ImFydW4ubXVyYWxpZGhhcmFuIn0.jr-Nrny0yGFuIUH8zHLuxpGH5aClwQVin2As2ISsgclu-9IDi1cVCtloIUNRb_ock6X7X41FtGMA_lt_T9wGyLmMzNf4Vu7OPBGfzjEdCHKD8OgcvI0Z4qw7_TFuXEuNSnbwkYFZ9S2g8uPzO0raVk4aIuczo58btwEDrsoE7TNBMTHjfL92zZ90YcFqW5WZKn9Y_dF1rb5UXARF6YSzzVjaNC86FWUl86wwo9cir0nxVPD4zKol_x2xyiP6n4n-sUX0_dM_-KMSfDqdr34quq3ZxcP5vjT-8FWb4t_IWHBmLrNsjS1so9a_5u7vcSBX1llX9Vgztv0zB7B8rEkFTw";
 
   std::string key = read_from_file(RSA256_PRIV_KEY);
@@ -63,7 +63,7 @@ TEST (RSAAlgo, RSA256EncodingDecodingTest)
   key = read_from_file(RSA256_PUB_KEY);
   ASSERT_TRUE (key.length());
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"rs256"}), ec, verify(false), secret(key));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"RS256"}), ec, verify(false), secret(key));
   EXPECT_FALSE (ec);
 }
 
@@ -74,7 +74,7 @@ TEST (RSAAlgo, RSA384EncodingDecodingTest)
   std::string key = read_from_file(RSA384_PRIV_KEY);
   ASSERT_TRUE (key.length());
 
-  const char* expected_str = 
+  const char* expected_str =
     "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhbGwiLCJleHAiOjE1MTM4NjIzNzIsImlzcyI6ImFydW4ubXVyYWxpZGhhcmFuIn0.iXQyGTmHAjdfXXgcMZn31xqv05h8Qoa3GGlSF5-42kPkd6iLPWzxky15FFW8qkvO-DiXDpOM4BoDANYCKNTSOToyuhCZ6dn_WH8RQzU6KOqRccYe2Fgvo7XnrgE_iHIMYPejc2kAUh1xLpE31WCU2P1afo2KN_-DV7kCmDJY6qpFtCctbbPNOhv6XbYpQlTblZeYDh1HVO--KWuhYl17kgjj3W-3fEoQjgaiprZ_JsTxRTN05aGT_AY15-FW0jPgPPBw5FnIX6P-j18F3BrG-lji7BuNrvyCUT3ZX35yBkBv9Ri5B3SLALy2bD0qGGE_G9_Orfm9yU9oQySLMO1qLiMbKLakLB5kMSy049C2Pdx9Nz47hqQWOHOWNRGwwTkKAwjeu1dTjv14QOmLcefM6GoXoCMZaFcmEqr63CgyLrnlsVS6vLkazyWcKD6eg51vPa8Rnn1V5u1EgNNnT6nU6iZ9_POJcf9_s-7HNpAXtlckia-OIrdLG-5cm93h1rAfVois43m0EwNtTr_DZ2JDtM9BifaS5MsktztUjrh1hjF5vDLBQc8vAYX0YbWOx_0NTn0aRYzOZ9kIhFxkaY320h8AS_7iFa5sA-ygeJdR-EvdlUZcoRzPzQFkrtatK-UE_VlSisUCsqoxHefx799aNjqz4FDLcyQRekdmVMb8Ew8";
 
   jwt::jwt_object obj{algorithm("RS384"), secret(key)};
@@ -91,7 +91,7 @@ TEST (RSAAlgo, RSA384EncodingDecodingTest)
   key = read_from_file(RSA384_PUB_KEY);
   ASSERT_TRUE (key.length());
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"none", "hs384", "rs384"}), verify(false), secret(key));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"none", "HS384", "RS384"}), verify(false), secret(key));
   EXPECT_EQ (dec_obj.header().algo(), jwt::algorithm::RS384);
 }
 
@@ -99,7 +99,7 @@ TEST (RSAAlgo, RSA512EncodingDecodingTest)
 {
   using namespace jwt::params;
 
-  const char* expected_str = 
+  const char* expected_str =
     "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhbGwiLCJleHAiOjE1MTM4NjIzNzIsImlzcyI6ImFydW4ubXVyYWxpZGhhcmFuIn0.ZNkLnf565-NFfxkbosJra1CJEgCLFf0jmgb7Q8eZrzxIrE4C4dOjpGD13f0jm2FqidUxAvFVrHI2ahhZi4Bu65qQtV4mVVftiD0qTaYzh26ql0MFqTKYEeKtU0kFXAzH7f9689z7mQ2n8aw7H8WHrfe17ub19Xyj-MirCECcWjcuGWBhsdz0y-dKy_GJYnpf8mHvmQAjkH5ynUV5NXHIBDO6eKssxX36Ow9_KYZ1HrCCUT_B-TQfNrnHAJgCydO-cX9iaAxV5aKvOdMGopHz14fX4oI9qH4aBzcroRbs77UsJZ-CMoRnUoXQP7DPORvEEUOQepANu9gqmymfJin8oEDotlj7eoJkFD3j64dkMT2bnRe8k2akPgUiDTeIrvNBuOIMDJtekoVpTo0fytveeDVPpDli9uX6DkJW1GGFLSRR-J-I8WbKRMKadmKOpDn3LF71hOo2mcXAsSwleFi9xB39bLBKJcqL_DtBoZBt0QSqMs6nRVj1U-3vYtuaa_eM3TfxhWWPZULaGVaVfpefRGdqtjrU0z5oO_vjviYujXK5_vM8zTroLVEaOyJYCeh2h_5N5LaOlf8BDu2PF3epNuCmM7G2PWEH7aPn5o-vvKTg_SM32jJXbXp2gkplEdQIWFh3jtjcRe9wNa9aPJE3I1hn1ZbqiAGUzBLWYUYpvstWXGbmxOoh6FkNJERb2hOIZgGLMvwWZXUU3GICcI5DMFOdDsuANpLg5FygsQ68JpuqKrUxu1Yh55--GHuDI7tqdHsPhPUzTmZrSvRog0w07dUAZCIBsGsSLX3wViobWbpVuY4pB7KXGIfdXgLfLgcERe_CxtnoPGF36zsqBflSXcqXwJ4qRK6BpTvKyUXf6pWEWOnuKomk8aENbT6nTr7naRJb5L3J4zhE-5O_Yetw9aCTzy9vN8a22n0JHXeroAwTpLR_wsQwDPwN-K99JVUKwR-FvOkJhE7_wwbUXmjiacKjXrwQ0OWnhXigQRLfdHG2OyH6_It5dpBmBOyWx2X-tfQ6Wz-_2bKCALl487Amq56hhNJhbQuJFIR59RylVAWKmfeeno2qcTZgrI_mO3PJCCUxBn5hK81HJuOtZ4YmeDHPvLW8Tiv5KqfRMWJKhyFthB74FvUINiEn0jvbuLR3YuyTgpf22lohT4-mHq5FrEd3plGvj0fVI_zeGhAFBhQYMW-MAJo7oylTOMtSZ1JHHuvBPR6FvMTgaPTAum6Dsl-I4_O_OKgtgovefBgwh4TOm_vsJmjVYFRr0Eo3OqsfNw3OwSKnuv5I76thh6DN879UZiyJG_7lcz_L6d0g4fGCvdM45zgQp3U3l8fJN1MRYCx5mxJAYeVlnCpmqueuww";
 
   std::string key = read_from_file(RSA512_PRIV_KEY);
@@ -118,7 +118,7 @@ TEST (RSAAlgo, RSA512EncodingDecodingTest)
   key = read_from_file(RSA512_PUB_KEY);
   ASSERT_TRUE (key.length());
 
-  auto dec_obj = jwt::decode(enc_str, algorithms({"none", "hs384", "rs512"}), verify(false), secret(key));
+  auto dec_obj = jwt::decode(enc_str, algorithms({"none", "HS384", "RS512"}), verify(false), secret(key));
   EXPECT_EQ (dec_obj.header().algo(), jwt::algorithm::RS512);
 }
 
@@ -139,7 +139,7 @@ TEST (RSAAlgo, NoSpecificAlgo)
   key = read_from_file(RSA512_PUB_KEY);
   ASSERT_TRUE (key.length());
 
-  EXPECT_THROW (jwt::decode(enc_str, algorithms({"none", "hs384", "rs384"}), verify(true), secret(key)),
+  EXPECT_THROW (jwt::decode(enc_str, algorithms({"none", "HS384", "RS384"}), verify(true), secret(key)),
                 jwt::InvalidAlgorithmError);
 }
 


### PR DESCRIPTION
The alg claim should always be treated as a case-sensitive value
according to the RFC spec which you can find here:

[https://tools.ietf.org/html/rfc7515#section-4.1.1](https://tools.ietf.org/html/rfc7515#section-4.1.1)

The same RFC spec also says it must be present, if it is empty
it is not present so it should not be converted to the "none"
algo as the "none" algo is an algorithm and not the absence of
one.

Finally the "none" algorithm as a string should be "none" not
"NONE" according to the IANA register for JWS Signature and
Encryption Algorithms which can be found here:

[https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms](https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms)