### PR TITLE
build: add add_library alias to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ else()
   add_definitions(-DCPP_JWT_USE_VENDORED_NLOHMANN_JSON)
 endif()
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_14)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 # ##############################################################################
 # TESTS


### PR DESCRIPTION
this makes it possible to do:

```cmake
find_package(cpp-jwt REQUIRED)
add_executable(main main.cpp)
target_link_libraries(main cpp-jwt::cpp-jwt)
```