### PR TITLE
fix: algorithm::NONE string representation capitalized, tests linkage fixes

### DIFF
--- a/include/jwt/algorithm.hpp
+++ b/include/jwt/algorithm.hpp
@@ -235,7 +235,7 @@ inline jwt::string_view alg_to_str(SCOPED_ENUM algorithm alg) noexcept
     case algorithm::ES384: return "ES384";
     case algorithm::ES512: return "ES512";
     case algorithm::TERM:  return "TERM";
-    case algorithm::NONE:  return "none";
+    case algorithm::NONE:  return "NONE";
     case algorithm::UNKN:  return "UNKN";
     default:               assert (0 && "Unknown Algorithm");
   };
@@ -251,7 +251,7 @@ inline SCOPED_ENUM algorithm str_to_alg(const jwt::string_view alg) noexcept
 {
   if (!alg.length()) return algorithm::UNKN;
 
-  if (!strcasecmp(alg.data(), "none"))  return algorithm::NONE;
+  if (!strcasecmp(alg.data(), "NONE"))  return algorithm::NONE;
   if (!strcasecmp(alg.data(), "HS256")) return algorithm::HS256;
   if (!strcasecmp(alg.data(), "HS384")) return algorithm::HS384;
   if (!strcasecmp(alg.data(), "HS512")) return algorithm::HS512;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -DCERT_ROOT_DIR=\"\\\"${CERT_ROOT_DIR}\\\"\"")
 
 add_executable(test_jwt_object test_jwt_object.cc)
-target_link_libraries(test_jwt_object ${GTest_LIBRARIES} ${PROJECT_NAME})
+target_link_libraries(test_jwt_object GTest::GTest GTest::Main ${PROJECT_NAME})
 target_include_directories(test_jwt_object PRIVATE ${GTEST_INCLUDE_DIRS}
                                                    ${GTest_INCLUDE_DIRS})
 add_test(
@@ -12,7 +12,7 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_jwt_encode test_jwt_encode.cc)
-target_link_libraries(test_jwt_encode ${GTest_LIBRARIES} ${PROJECT_NAME})
+target_link_libraries(test_jwt_encode GTest::GTest GTest::Main ${PROJECT_NAME})
 target_include_directories(test_jwt_encode PRIVATE ${GTEST_INCLUDE_DIRS}
                                                    ${GTest_INCLUDE_DIRS})
 add_test(
@@ -21,7 +21,7 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_jwt_decode test_jwt_decode.cc)
-target_link_libraries(test_jwt_decode ${GTest_LIBRARIES} ${PROJECT_NAME})
+target_link_libraries(test_jwt_decode GTest::GTest GTest::Main ${PROJECT_NAME})
 target_include_directories(test_jwt_decode PRIVATE ${GTEST_INCLUDE_DIRS}
                                                    ${GTest_INCLUDE_DIRS})
 add_test(
@@ -30,7 +30,7 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_jwt_decode_verifiy test_jwt_decode_verifiy.cc)
-target_link_libraries(test_jwt_decode_verifiy ${GTest_LIBRARIES}
+target_link_libraries(test_jwt_decode_verifiy GTest::GTest GTest::Main
                       ${PROJECT_NAME})
 target_include_directories(test_jwt_decode_verifiy
                            PRIVATE ${GTEST_INCLUDE_DIRS} ${GTest_INCLUDE_DIRS})
@@ -41,7 +41,7 @@ add_test(
 
 add_executable(test_jwt_decode_verifiy_with_exception
                test_jwt_decode_verifiy_with_exception.cc)
-target_link_libraries(test_jwt_decode_verifiy_with_exception ${GTest_LIBRARIES}
+target_link_libraries(test_jwt_decode_verifiy_with_exception GTest::GTest GTest::Main
                       ${PROJECT_NAME})
 target_include_directories(test_jwt_decode_verifiy_with_exception
                            PRIVATE ${GTEST_INCLUDE_DIRS} ${GTest_INCLUDE_DIRS})
@@ -51,7 +51,7 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_jwt_rsa test_jwt_rsa.cc)
-target_link_libraries(test_jwt_rsa ${GTest_LIBRARIES} ${PROJECT_NAME})
+target_link_libraries(test_jwt_rsa GTest::GTest GTest::Main ${PROJECT_NAME})
 target_include_directories(test_jwt_rsa PRIVATE ${GTEST_INCLUDE_DIRS}
                                                 ${GTest_INCLUDE_DIRS})
 add_test(
@@ -60,7 +60,7 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_jwt_es test_jwt_es.cc)
-target_link_libraries(test_jwt_es ${GTest_LIBRARIES} ${PROJECT_NAME})
+target_link_libraries(test_jwt_es GTest::GTest GTest::Main ${PROJECT_NAME})
 target_include_directories(test_jwt_es PRIVATE ${GTEST_INCLUDE_DIRS}
                                                ${GTest_INCLUDE_DIRS})
 add_test(

--- a/tests/test_jwt_decode.cc
+++ b/tests/test_jwt_decode.cc
@@ -186,7 +186,3 @@ TEST (DecodeTest, TypHeaderMiss)
   EXPECT_FALSE (ec);
 }
 
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tests/test_jwt_decode_verifiy.cc
+++ b/tests/test_jwt_decode_verifiy.cc
@@ -194,7 +194,3 @@ TEST (DecodeVerify, InvalidSignatureTest)
   EXPECT_EQ (ec.value(), static_cast<int>(jwt::DecodeErrc::SignatureFormatError));
 }
 
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tests/test_jwt_decode_verifiy_with_exception.cc
+++ b/tests/test_jwt_decode_verifiy_with_exception.cc
@@ -176,7 +176,3 @@ TEST (DecodeVerifyExp, InvalidSubjectTest)
                 jwt::InvalidSubjectError);
 }
 
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tests/test_jwt_encode.cc
+++ b/tests/test_jwt_encode.cc
@@ -312,8 +312,3 @@ TEST (EncodeTest, HeaderParamTest)
   std::cout << dec_obj.header() << std::endl;
 }
 
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tests/test_jwt_es.cc
+++ b/tests/test_jwt_es.cc
@@ -147,7 +147,3 @@ TEST (ESAlgo, ES384EncodingDecodingValidTest)
   EXPECT_EQ (dec_obj2.header().algo(), jwt::algorithm::ES384);
 }
 
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tests/test_jwt_object.cc
+++ b/tests/test_jwt_object.cc
@@ -28,8 +28,3 @@ TEST (ObjectTest, MoveConstructor)
   EXPECT_TRUE(wrapper.object.payload().has_claim_with_value("iss", "arun.muralidharan"));
 }
 
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tests/test_jwt_rsa.cc
+++ b/tests/test_jwt_rsa.cc
@@ -143,7 +143,3 @@ TEST (RSAAlgo, NoSpecificAlgo)
                 jwt::InvalidAlgorithmError);
 }
 
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
Hi!
Faced problems with compiling and running tests.
1. ${GTest_LIBRARIES} appears to be empty on my OS (Linux Mint 19.3), seems to be case-sensitivity issue, fixed by linking against GTest::GTest GTest::Main, also linking against GTest::Main makes main method manually placed in every test redundant.
2. Also case-sensitivity issue. test_jwt_encode test wouldn't pass, judging by the assert (line 120), it expects algorithm::NONE to be serialized in capital letters which won't happen. I capitalized algorithm::NONE string representation ('NONE') label, which seems logical from my perspective, since all other algorithms are capitalized.