### PR TITLE
fix: C preprocessor defaults undefined macros to 0

### DIFF
--- a/include/jwt/algorithm.hpp
+++ b/include/jwt/algorithm.hpp
@@ -518,7 +518,7 @@ private:
    */
   static std::string public_key_ser(EVP_PKEY* pkey, jwt::string_view sign, std::error_code& ec);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER < 0x20700000L
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L
 
   //ATTN: Below 2 functions
   //are Taken from https://github.com/nginnever/zogminer/issues/39


### PR DESCRIPTION
Without this patch, this isn't compiling on my newer version of OpenSSL as I am not using LibreSSL (which is then 0, less than any version)... I imagine that, without this patch, it also wouldn't be working for people using newer LibreSSL.