### PR TITLE
fix: add new case to AlgorithmErrCategory::message

### DIFF
--- a/include/jwt/impl/error_codes.ipp
+++ b/include/jwt/impl/error_codes.ipp
@@ -48,6 +48,8 @@ struct AlgorithmErrCategory: std::error_category
       return "key not provided";
     case AlgorithmErrc::NoneAlgorithmUsed:
       return "none algorithm used";
+    case AlgorithmErrc::InvalidKeyErr:
+      return "invalid key";
     };
     return "unknown algorithm error";
     assert (0 && "Code not reached");


### PR DESCRIPTION
Without this patch, InvalidKeyError would result in "unknown algorithm error", and if you are using -Wswitch (such as I am) then the code doesn't compile at all.

```
./p2p/cpp-jwt/include/jwt/impl/error_codes.ipp:41:13: error: enumeration value 'InvalidKeyErr' not handled in switch [-Werror,-Wswitch]
    switch (static_cast<AlgorithmErrc>(ev))
            ^
```