### PR TITLE
fix: typo

### DIFF
--- a/include/jwt/jwt.hpp
+++ b/include/jwt/jwt.hpp
@@ -898,7 +898,7 @@ public: // 'tors
 
 public: // Exposed static APIs
   /**
-   * Splitsa JWT string into its three parts
+   * Splits a JWT string into its three parts
    * using dot('.') as the delimiter.
    *
    * @note: Instead of actually splitting the API


### PR DESCRIPTION
add a necessary space to split two concatenated words