### PR TITLE
vcpkg related CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.5.0)
-project(cpp-jwt VERSION 1.2.0)
+cmake_minimum_required(VERSION 3.14.0)
+project(cpp-jwt VERSION 1.5.0)
 
 option(CPP_JWT_BUILD_EXAMPLES "build examples" ON)
 option(CPP_JWT_BUILD_TESTS "build tests" ON)
@@ -43,7 +43,7 @@ target_link_libraries(${PROJECT_NAME} INTERFACE OpenSSL::SSL)
 if(NOT CPP_JWT_USE_VENDORED_NLOHMANN_JSON)
   target_link_libraries(${PROJECT_NAME} INTERFACE nlohmann_json::nlohmann_json)
 else()
-  add_definitions(-DCPP_JWT_USE_VENDORED_NLOHMANN_JSON)
+  target_compile_definitions(${PROJECT_NAME} INTERFACE CPP_JWT_USE_VENDORED_NLOHMANN_JSON)
 endif()
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_14)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
@@ -90,30 +90,27 @@ install(
   NAMESPACE ${PROJECT_NAME}::
   COMPONENT dev)
 configure_package_config_file(cmake/Config.cmake.in ${PROJECT_NAME}Config.cmake
-                              INSTALL_DESTINATION ${CPP_JWT_CONFIG_INSTALL_DIR})
+                              PATH_VARS CPP_JWT_CONFIG_INSTALL_DIR
+                              INSTALL_DESTINATION ${CPP_JWT_CONFIG_INSTALL_DIR} 
+                              NO_SET_AND_CHECK_MACRO)
 write_basic_package_version_file(${PROJECT_NAME}ConfigVersion.cmake
-                                 COMPATIBILITY SameMajorVersion)
+                                 COMPATIBILITY SameMajorVersion
+                                 ARCH_INDEPENDENT)
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
   DESTINATION ${CPP_JWT_CONFIG_INSTALL_DIR}
   COMPONENT dev)
 
-install(
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/jwt/detail
-  DESTINATION include/jwt
-  COMPONENT dev)
-install(
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/jwt/impl
-  DESTINATION include/jwt
-  COMPONENT dev)
-install(
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/jwt/json
-  DESTINATION include/jwt
-  COMPONENT dev)
+if(NOT CPP_JWT_USE_VENDORED_NLOHMANN_JSON)
+  set(CPP_JWT_VENDORED_NLOHMANN_JSON_INSTALL_PATTERN PATTERN "json" EXCLUDE)
+endif()
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/jwt/
   DESTINATION include/jwt
   COMPONENT dev
   FILES_MATCHING
-  PATTERN "*.hpp")
+  PATTERN "*.hpp"
+  PATTERN "*.ipp"
+  PATTERN "test" EXCLUDE
+  ${CPP_JWT_VENDORED_NLOHMANN_JSON_INSTALL_PATTERN})

--- a/README.md
+++ b/README.md
@@ -136,16 +136,16 @@ Few good resources on this material which I found useful are:
       //Most APIs have an overload which takes enum class type as well
       //It can be used interchangeably with strings.
       obj.remove_claim(jwt::registered_claims::expiration);
-      assert (not obj.has_claim("exp"));
+      assert (!obj.has_claim("exp"));
 
       //Using `add_claim` with extra features.
       //Check return status and overwrite
       bool ret = obj.payload().add_claim("sub", "new test", false/*overwrite*/);
-      assert (not ret);
+      assert (!ret);
 
       // Overwrite an existing claim
       ret = obj.payload().add_claim("sub", "new test", true/*overwrite*/);
-      assert ( ret );
+      assert (ret);
 
       assert (obj.payload().has_claim_with_value("sub", "new test"));
 
@@ -234,7 +234,7 @@ cmake --build . -j
 
 ## Consuming the library
 
-this library is uses cmake as a build system.
+This library is uses cmake as a build system.
 ```cmake
 # you can use cmake's `find_package` after installation or `add_subdirectory` when vendoring this repository
 
@@ -246,8 +246,10 @@ add_executable(main main.cpp)
 target_link_libraries(main cpp-jwt::cpp-jwt)
 ```
 
-you can also use this library as a conan package, its available in the [conan center](https://conan.io/center/cpp-jwt/1.2/?user=_&channel=_):
-just add `cpp-jwt[>=1.2]` to your conanfile.txt
+You can also use this library as a conan package, its available in the [conan center](https://conan.io/center/cpp-jwt):
+just add `cpp-jwt[>=1.2]` to your conanfile.txt.
+
+It can also be installed using [vcpkg](https://github.com/microsoft/vcpkg) by adding `"cpp-jwt"` to the dependencies in your `vcpkg.json` file.
 
 ## Parameters
 There are two sets of parameters which can be used for creating `jwt_object` and for decoding.

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -6,5 +6,5 @@ endif()
 
 find_package(OpenSSL REQUIRED)
 
-include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+include("@PACKAGE_CPP_JWT_CONFIG_INSTALL_DIR@/@PROJECT_NAME@Targets.cmake")
 check_required_components("@PROJECT_NAME@")

--- a/examples/simple_ex2.cc
+++ b/examples/simple_ex2.cc
@@ -33,11 +33,11 @@ int main() {
   //Most APIs have an overload which takes enum class type as well
   //It can be used interchangeably with strings.
   obj.remove_claim(jwt::registered_claims::expiration);
-  assert (not obj.has_claim("exp"));
+  assert (!obj.has_claim("exp"));
 
   //Using `add_claim` with extra features.
   //Check return status and overwrite
-  assert (not obj.payload().add_claim("sub", "new test", false/*overwrite*/));
+  assert (!obj.payload().add_claim("sub", "new test", false/*overwrite*/));
 
   // Overwrite an existing claim
   assert (obj.payload().add_claim("sub", "new test", true/*overwrite*/));

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "cpp-jwt",
+  "version": "1.5",
+  "description": "JSON Web Token library for C++",
+  "homepage": "https://github.com/arun11299/cpp-jwt",
+  "dependencies": [
+    "nlohmann-json",
+    "openssl",
+    "gtest"
+  ]
+}


### PR DESCRIPTION
* Fix missing compile definition when installing the package with `CPP_JWT_USE_VENDORED_NLOHMANN_JSON` set to `on` by adding `target_compile_definitions(${PROJECT_NAME} INTERFACE CPP_JWT_USE_VENDORED_NLOHMANN_JSON)` (requires CMake 3.11).
* Make installed package compatible with x86 even when it was build with x64 by adding `ARCH_INDEPENDENT` to `write_basic_package_version_file` (requires CMake 3.14).
* Exclude empty `test/` directory and `json/test_json.cc` file from installation. Requirement of vcpkg.
* Do not rely on CMake implementation detail regarding `CMAKE_CURRENT_LIST_DIR` in `Config.cmake.in`, use `PATH_VARS` of `configure_package_config_file` instead
* Mention that we are available on [vcpkg](https://github.com/microsoft/vcpkg) in the README.
* Fix compilation of examples on Windows by replacing `not` with `!`.
* Add vcpkg.json file to make it easier for contributors to work on the project. Just install [vcpkg](https://github.com/microsoft/vcpkg) and configure the project with `-DCMAKE_TOOLCHAIN_FILE=<path_to_vcpkg>/scripts/buildsystems/vcpkg.cmake`
* Bump version to 1.5.0.