### PR TITLE
Fix Config.cmake.in not relocatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,6 @@ install(
   NAMESPACE ${PROJECT_NAME}::
   COMPONENT dev)
 configure_package_config_file(cmake/Config.cmake.in ${PROJECT_NAME}Config.cmake
-                              PATH_VARS CPP_JWT_CONFIG_INSTALL_DIR
                               INSTALL_DESTINATION ${CPP_JWT_CONFIG_INSTALL_DIR} 
                               NO_SET_AND_CHECK_MACRO)
 write_basic_package_version_file(${PROJECT_NAME}ConfigVersion.cmake

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -6,5 +6,5 @@ endif()
 
 find_package(OpenSSL REQUIRED)
 
-include("@PACKAGE_CPP_JWT_CONFIG_INSTALL_DIR@/@PROJECT_NAME@Targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
Turns out vcpkg actually relocates the installed `cpp-jwtTargets.cmake` from `CPP_JWT_CONFIG_INSTALL_DIR` to `share/cpp-jwt` so the only option I see is to use `CMAKE_CURRENT_LIST_DIR` like we did before. Sorry for that oversight.