### PR TITLE
Fix out-of-bounds access in three_parts and mishandling of non-null terminated string_views in jwt_set::case_compare

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@ name: CMake
 on: [push, pull_request]
 
 env:
-  BUILD_TYPE: Release
-  CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Release -DCPP_JWT_USE_VENDORED_NLOHMANN_JSON=off'
+  BUILD_TYPE: Debug
+  CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Debug -DCPP_JWT_USE_VENDORED_NLOHMANN_JSON=off'
   VCPKG_ARGUMENTS: 'nlohmann-json openssl gtest'
-  VCPKG_VERSION: '699c8779f1b0feb4ed3564716d1ed31f69663ea6' # Oct 16, 2021
+  VCPKG_VERSION: '6be82cfac67649a31d4c3eba56d2fafa9dc6736a' # May 13, 2022
 
 jobs:
   build:

--- a/include/jwt/algorithm.hpp
+++ b/include/jwt/algorithm.hpp
@@ -358,7 +358,7 @@ struct HMACSign
 
     unsigned char* res = HMAC(Hasher{}(),
                               key.data(),
-                              key.length(),
+                              static_cast<int>(key.length()),
                               reinterpret_cast<const unsigned char*>(data.data()),
                               data.length(),
                               reinterpret_cast<unsigned char*>(&sign[0]),

--- a/include/jwt/impl/algorithm.ipp
+++ b/include/jwt/impl/algorithm.ipp
@@ -38,7 +38,7 @@ verify_result_t HMACSign<Hasher>::verify(
 
   unsigned char* res = HMAC(Hasher{}(),
                             key.data(),
-                            key.length(),
+                            static_cast<int>(key.length()),
                             reinterpret_cast<const unsigned char*>(head.data()),
                             head.length(),
                             enc_buf,
@@ -79,7 +79,7 @@ verify_result_t PEMSign<Hasher>::verify(
   std::string dec_sig = base64_uri_decode(jwt_sign.data(), jwt_sign.length());
 
   BIO_uptr bufkey{
-      BIO_new_mem_buf((void*)key.data(), key.length()),
+      BIO_new_mem_buf((void*)key.data(), static_cast<int>(key.length())),
       bio_deletor};
 
   if (!bufkey) {
@@ -180,7 +180,7 @@ EVP_PKEY* PEMSign<Hasher>::load_key(
   ec.clear();
 
   BIO_uptr bio_ptr{
-      BIO_new_mem_buf((void*)key.data(), key.length()), 
+      BIO_new_mem_buf((void*)key.data(), static_cast<int>(key.length())), 
       bio_deletor};
 
   if (!bio_ptr) {
@@ -276,7 +276,7 @@ std::string PEMSign<Hasher>::public_key_ser(
 
   EC_SIG_uptr ec_sig{d2i_ECDSA_SIG(nullptr,
                                    (const unsigned char**)&char_ptr,
-                                   sign.length()),
+                                   static_cast<long>(sign.length())),
                      ec_sig_deletor};
 
   if (!ec_sig) {

--- a/include/jwt/impl/error_codes.ipp
+++ b/include/jwt/impl/error_codes.ipp
@@ -52,7 +52,6 @@ struct AlgorithmErrCategory: std::error_category
       return "invalid key";
     };
     return "unknown algorithm error";
-    assert (0 && "Code not reached");
   }
 };
 
@@ -89,7 +88,6 @@ struct DecodeErrorCategory: std::error_category
       return "key not required for NONE algorithm";
     };
     return "unknown decode error";
-    assert (0 && "Code not reached");
   }
 };
 
@@ -128,7 +126,6 @@ struct VerificationErrorCategory: std::error_category
       return "type conversion error";
     };
     return "unknown verification error";
-    assert (0 && "Code not reached");
   }
 };
 

--- a/include/jwt/impl/jwt.ipp
+++ b/include/jwt/impl/jwt.ipp
@@ -70,7 +70,7 @@ inline void jwt_header::decode(const jwt::string_view enc_str, std::error_code& 
 
   try {
     payload_ = json_t::parse(std::move(json_str));
-  } catch(const std::exception& e) {
+  } catch(const std::exception&) {
     ec = DecodeErrc::JsonParseError;
     return;
   }
@@ -130,7 +130,7 @@ inline void jwt_payload::decode(const jwt::string_view enc_str, std::error_code&
   std::string json_str = base64_decode(enc_str);
   try {
     payload_ = json_t::parse(std::move(json_str));
-  } catch(const std::exception& e) {
+  } catch(const std::exception&) {
     ec = DecodeErrc::JsonParseError;
     return;
   }
@@ -530,7 +530,7 @@ jwt_object::three_parts(const jwt::string_view enc_str)
 
   result[1] = jwt::string_view{&enc_str[fpos + 1], spos - fpos - 1};
 
-  if (spos != enc_str.length()) {
+  if (spos + 1 != enc_str.length()) {
     result[2] = jwt::string_view{&enc_str[spos + 1], enc_str.length() - spos - 1};
   }
 
@@ -711,7 +711,7 @@ jwt_object decode(const jwt::string_view enc_str,
   if (dparams.verify) {
     try {
       ec = obj.verify(dparams, algos);
-    } catch (const json_ns::detail::type_error& e) {
+    } catch (const json_ns::detail::type_error&) {
       ec = VerificationErrc::TypeConversionError;
     }
 

--- a/include/jwt/impl/string_view.ipp
+++ b/include/jwt/impl/string_view.ipp
@@ -273,7 +273,7 @@ namespace {
  */
 
 inline size_t
-unaligned_load(const char* p)
+unaligned_load(const char* p) noexcept
 {
   std::size_t result;
   std::memcpy(&result, p, sizeof(result));
@@ -281,7 +281,7 @@ unaligned_load(const char* p)
 }
 
 inline size_t
-hash_bytes(const void* ptr, size_t len, size_t seed)
+hash_bytes(const void* ptr, size_t len, size_t seed) noexcept
 {
   const size_t m = 0x5bd1e995;
   size_t hash = seed ^ len;
@@ -329,7 +329,7 @@ namespace std {
   template <>
   struct hash<jwt::string_view>
   {
-    size_t operator()(const jwt::string_view& sv) const
+    size_t operator()(const jwt::string_view& sv) const noexcept
     {
       return jwt::hash_bytes((void*)sv.data(), sv.length(), static_cast<size_t>(0xc70f6907UL));
     }

--- a/include/jwt/jwt.hpp
+++ b/include/jwt/jwt.hpp
@@ -72,7 +72,6 @@ inline enum type str_to_type(const jwt::string_view typ) noexcept
   else if(!strcasecmp(typ.data(), "none")) return type::NONE;
 
   JWT_NOT_REACHED("Code not reached");
-  return type::NONE;
 }
 
 
@@ -130,7 +129,6 @@ inline jwt::string_view reg_claims_to_str(SCOPED_ENUM registered_claims claim) n
     default:                            assert (0 && "Not a registered claim");
   };
   JWT_NOT_REACHED("Code not reached");
-  return "";
 }
 
 /**
@@ -147,27 +145,9 @@ struct jwt_set
   {
     using is_transparent = std::true_type;
 
-    bool operator()(const std::string& lhs, const std::string& rhs) const
-    {
-      int ret = strcmp(lhs.c_str(), rhs.c_str());
-      return (ret < 0);
-    }
-
     bool operator()(const jwt::string_view lhs, const jwt::string_view rhs) const
     {
-      int ret = strcmp(lhs.data(), rhs.data());
-      return (ret < 0);
-    }
-
-    bool operator()(const std::string& lhs, const jwt::string_view rhs) const
-    {
-      int ret = strcmp(lhs.data(), rhs.data());
-      return (ret < 0);
-    }
-
-    bool operator()(const jwt::string_view lhs, const std::string& rhs) const
-    {
-      int ret = strcmp(lhs.data(), rhs.data());
+      int ret = lhs.compare(rhs);
       return (ret < 0);
     }
   };

--- a/include/jwt/jwt.hpp
+++ b/include/jwt/jwt.hpp
@@ -145,7 +145,7 @@ struct jwt_set
   {
     using is_transparent = std::true_type;
 
-    bool operator()(const jwt::string_view lhs, const jwt::string_view rhs) const
+    bool operator()(const jwt::string_view lhs, const jwt::string_view rhs) const noexcept
     {
       int ret = lhs.compare(rhs);
       return (ret < 0);

--- a/include/jwt/string_view.hpp
+++ b/include/jwt/string_view.hpp
@@ -138,6 +138,7 @@ public: // Exposed APIs
   /// Element Access Member Functions
   const_reference operator[](size_type idx) const noexcept
   {
+    assert(idx < len_ && "string_view subscript out of range");
     return data_[idx];
   }
 


### PR DESCRIPTION
Fix out-of-bounds access in three_parts, added an assertion to jwt::string_view to prevent future such errors. Also set CI pipeline build type to Debug.   
Fix mishandling of non-null terminated string_views in jwt_set::case_compare, also add noexcept.   
Address several conversion and unreachability warnings.

This  also fixes a compiler error when using MSVC 17.2 and /std:c++latest

```
[build] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\include\xmemory(52): error C3066: there are multiple ways that an object of this type can be called with these arguments
[build] C:\3YOURMIND\cpp-jwt\include\jwt/jwt.hpp(148): note: could be 'bool jwt::jwt_set::case_compare::operator ()(const std::string &,const std::string &) const'
[build] C:\3YOURMIND\cpp-jwt\include\jwt/jwt.hpp(160): note: or       'bool jwt::jwt_set::case_compare::operator ()(const std::string &,const jwt::string_view) const'
[build] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\include\xmemory(51): note: while trying to match the argument list '(const std::string, const char *const )'
[build] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\include\xtree(1683): note: see reference to variable template 'const bool _Nothrow_compare<jwt::jwt_set::case_compare,std::basic_string<char,std::char_traits<char>,std::allocator<char> >,char const *>' being compiled
[build] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\include\xtree(1682): note: while compiling class template member function 'std::pair<std::_Tree_node<std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::_Default_allocator_traits<_Alloc>::void_pointer> *,std::_Tree_node<std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::_Default_allocator_traits<_Alloc>::void_pointer> *> std::_Tree<std::_Tset_traits<_Kty,_Pr,_Alloc,false>>::_Eqrange<_Kx>(const _Other &) noexcept(<expr>) const'
[build]         with
[build]         [
[build]             _Alloc=std::allocator<std::string>,
[build]             _Kty=std::string,
[build]             _Pr=jwt::jwt_set::case_compare,
[build]             _Kx=const char *,
[build]             _Other=const char *
[build]         ]
[build] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\include\xtree(1338): note: while compiling class template member function 'unsigned __int64 std::_Tree<std::_Tset_traits<_Kty,_Pr,_Alloc,false>>::erase<const char*,jwt::jwt_set::case_compare,std::true_type,0>(_Kx &&) noexcept(<expr>)'
[build]         with
[build]         [
[build]             _Kty=std::string,
[build]             _Pr=jwt::jwt_set::case_compare,
[build]             _Alloc=std::allocator<std::string>,
[build]             _Kx=const char *
[build]         ]
[build] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\include\xmemory(52): error C3066: there are multiple ways that an object of this type can be called with these arguments
[build] C:\3YOURMIND\cpp-jwt\include\jwt/jwt.hpp(148): note: could be 'bool jwt::jwt_set::case_compare::operator ()(const std::string &,const std::string &) const'
[build] C:\3YOURMIND\cpp-jwt\include\jwt/jwt.hpp(160): note: or       'bool jwt::jwt_set::case_compare::operator ()(const std::string &,const jwt::string_view) const'
[build] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\include\xmemory(52): note: while trying to match the argument list '(const std::string, const char *const )'
[build] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\include\xmemory(51): error C2056: illegal expression
```