### PR TITLE
cmake: fix dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
 endif()
 
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL REQUIRED SSL)
 
 if(NOT CPP_JWT_USE_VENDORED_NLOHMANN_JSON)
   find_package(nlohmann_json REQUIRED)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,10 +1,12 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
 if(NOT @CPP_JWT_USE_VENDORED_NLOHMANN_JSON@)
-  find_package(nlohmann_json REQUIRED)
+  find_dependency(nlohmann_json)
 endif()
 
-find_package(OpenSSL REQUIRED)
+find_dependency(OpenSSL COMPONENTS SSL)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
`find_package` should be replaced by [find_dependency](https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html) in CMake config files.
Currently `find_package(cpp-jwt QUIET)` will produce a fatal error if OpenSSL is not found instead of failing silently (`cpp-jwt` is not a required dependency here).