### PR TITLE
fix: Multiple definitions when including jwt.hpp from different files

### DIFF
--- a/include/jwt/impl/algorithm.ipp
+++ b/include/jwt/impl/algorithm.ipp
@@ -25,7 +25,7 @@ SOFTWARE.
 
 namespace jwt {
 
-verify_result_t is_secret_a_public_key(const jwt::string_view secret)
+inline verify_result_t is_secret_a_public_key(const jwt::string_view secret)
 {
   std::error_code ec{};
 


### PR DESCRIPTION
Issue happens when compiling with gcc 15

Closes #104 

This PR is mainly here to provide [a downloadable patch file](https://github.com/arun11299/cpp-jwt/commit/20086d7198a3636280ebb90b11b5a18495831c8a.patch) that is easy to integrate into a packaging script.

I do not care about attribution, feel free to include in another commit and close this PR :)